### PR TITLE
Fix an apparent misunderstanding with pessimistic matching

### DIFF
--- a/cookbook/cookbook.go
+++ b/cookbook/cookbook.go
@@ -944,7 +944,7 @@ func verConstraintCheck(ver_a, ver_b, op string) string {
 		case "~>":
 			/* only check pessimistic constraints if they can
 			 * possibly be valid. */
-			if ver_a == ver_b || versionLess(ver_a, ver_b) {
+			if versionLess(ver_a, ver_b) {
 				return "break"
 			}
 			var upper_bound string


### PR DESCRIPTION
Seems I misunderstood pessimistic matching in http://docs.opscode.com/essentials_cookbook_versions.html#constraints -- the version constraint check was explicitly disallowing an exact match with ~>.
