### PR TITLE
Postgres node search prototype

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -449,10 +449,8 @@ func (c *Client) Index() string {
 }
 
 // Flatten out the client so it's suitable for indexing.
-func (c *Client) Flatten() []string {
-	flatten := util.FlattenObj(c.flatExport())
-	indexified := util.Indexify(flatten)
-	return indexified
+func (c *Client) Flatten() map[string]interface{} {
+	return util.FlattenObj(c.flatExport())
 }
 
 /* Permission functions. Later role-based perms may be implemented, but for now

--- a/databag/databag.go
+++ b/databag/databag.go
@@ -415,7 +415,7 @@ func (dbi *DataBagItem) Index() string {
 }
 
 // Flatten a data bag item out so it's suitable for indexing.
-func (dbi *DataBagItem) Flatten() []string {
+func (dbi *DataBagItem) Flatten() map[string]interface{} {
 	flatten := make(map[string]interface{})
 	for key, v := range dbi.RawData {
 		subExpand := util.DeepMerge(key, v)
@@ -423,8 +423,7 @@ func (dbi *DataBagItem) Flatten() []string {
 			flatten[k] = u
 		}
 	}
-	indexified := util.Indexify(flatten)
-	return indexified
+	return flatten
 }
 
 // AllDataBags returns all data bags on this server, and all their items.

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -407,10 +407,8 @@ func (e *ChefEnvironment) Index() string {
 }
 
 // Flatten the environment so it's suitable for indexing.
-func (e *ChefEnvironment) Flatten() []string {
-	flatten := util.FlattenObj(e)
-	indexified := util.Indexify(flatten)
-	return indexified
+func (e *ChefEnvironment) Flatten() map[string]interface{} {
+	return util.FlattenObj(e)
 }
 
 // AllEnvironments returns a slice of all environments on this server.

--- a/goiardi.go
+++ b/goiardi.go
@@ -75,6 +75,7 @@ func main() {
 
 	gobRegister()
 	ds := datastore.New()
+	indexer.Initialize(config.Config)
 	if config.Config.FreezeData {
 		if config.Config.DataStoreFile != "" {
 			uerr := ds.Load(config.Config.DataStoreFile)
@@ -83,7 +84,7 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		ierr := indexer.LoadIndex(config.Config.IndexFile)
+		ierr := indexer.LoadIndex()
 		if ierr != nil {
 			logger.Criticalf(ierr.Error())
 			os.Exit(1)
@@ -116,7 +117,7 @@ func main() {
 					logger.Errorf(err.Error())
 				}
 			}
-			if err := indexer.SaveIndex(config.Config.IndexFile); err != nil {
+			if err := indexer.SaveIndex(); err != nil {
 				logger.Errorf(err.Error())
 			}
 		}
@@ -404,7 +405,7 @@ func handleSignals() {
 							logger.Errorf(err.Error())
 						}
 					}
-					if err := indexer.SaveIndex(config.Config.IndexFile); err != nil {
+					if err := indexer.SaveIndex(); err != nil {
 						logger.Errorf(err.Error())
 					}
 				}
@@ -442,12 +443,6 @@ func gobRegister() {
 	gob.Register(m)
 	var si []interface{}
 	gob.Register(si)
-	i := new(indexer.Index)
-	ic := new(indexer.IdxCollection)
-	id := new(indexer.IdxDoc)
-	gob.Register(i)
-	gob.Register(ic)
-	gob.Register(id)
 	var ss []string
 	gob.Register(ss)
 	ms := make(map[string]string)
@@ -494,7 +489,7 @@ func setSaveTicker() {
 						logger.Errorf(uerr.Error())
 					}
 				}
-				ierr := indexer.SaveIndex(config.Config.IndexFile)
+				ierr := indexer.SaveIndex()
 				if ierr != nil {
 					logger.Errorf(ierr.Error())
 				}

--- a/indexer/file_index.go
+++ b/indexer/file_index.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ctdk/go-trie/gtrie"
 	"github.com/ctdk/goas/v2/logger"
 	"github.com/philhofer/msgp/msgp"
+	"github.com/ctdk/goiardi/util"
 	"os"
 	"path"
 	"regexp"
@@ -343,7 +344,7 @@ func (ic *IdxCollection) allDocs() map[string]*Document {
 func (idoc *IdxDoc) update(object Indexable) {
 	idoc.m.Lock()
 	defer idoc.m.Unlock()
-	flattened := object.Flatten()
+	flattened := util.Indexify(object.Flatten())
 	flatText := strings.Join(flattened, "\n")
 	/* recover from horrific trie errors that seem to happen with really
 	 * big values. :-/ */

--- a/indexer/file_index.go
+++ b/indexer/file_index.go
@@ -61,6 +61,8 @@ func (i *FileIndex) initialize() {
 	gob.Register(in)
 	gob.Register(ic)
 	gob.Register(id)
+
+	i.makeDefaultCollections()
 }
 
 func (i *FileIndex) createCollection(idxName string) {
@@ -157,6 +159,10 @@ func (i *FileIndex) endpoints() []string {
 
 	sort.Strings(endpoints)
 	return endpoints
+}
+
+func (i *FileIndex) clear() {
+	i.makeDefaultCollections()
 }
 
 func (i *FileIndex) makeDefaultCollections() {

--- a/indexer/file_index.go
+++ b/indexer/file_index.go
@@ -1,0 +1,681 @@
+package indexer
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/gob"
+	"github.com/ctdk/go-trie/gtrie"
+	"github.com/ctdk/goas/v2/logger"
+	"github.com/philhofer/msgp/msgp"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+	"fmt"
+	"sort"
+	"io/ioutil"
+)
+
+type FileIndex struct {
+	file    string
+	m       sync.RWMutex
+	idxmap  map[string]IndexCollection
+	updated bool
+}
+
+// IdxCollection holds a map of documents.
+type IdxCollection struct {
+	m    sync.RWMutex
+	docs map[string]*IdxDoc
+}
+
+// IdxDoc is the indexed documents that are actually searched.
+type IdxDoc struct {
+	m       sync.RWMutex
+	trie    []byte
+	docText []byte
+}
+
+type searchRes struct {
+	key string
+	doc *IdxDoc
+}
+
+/* Index methods */
+
+func (i *FileIndex) initialize() {
+	in := new(FileIndex)
+	ic := new(IdxCollection)
+	id := new(IdxDoc)
+	gob.Register(in)
+	gob.Register(ic)
+	gob.Register(id)
+}
+
+func (i *FileIndex) createCollection(idxName string) {
+	i.updated = true
+
+	if _, ok := i.idxmap[idxName]; !ok {
+		coll := new(IdxCollection)
+		coll.docs = make(map[string]*IdxDoc)
+		casted := IndexCollection(coll)
+		i.idxmap[idxName] = casted
+	}
+}
+
+func (i *FileIndex) deleteCollection(idxName string) {
+	i.m.Lock()
+	defer i.m.Unlock()
+	i.updated = true
+	delete(i.idxmap, idxName)
+}
+
+func (i *FileIndex) saveIndex(object Indexable) {
+	/* Have to check to see if data bag indexes exist */
+	i.m.Lock()
+	defer i.m.Unlock()
+	i.updated = true
+	if _, found := i.idxmap[object.Index()]; !found {
+		i.createCollection(object.Index())
+	}
+	i.idxmap[object.Index()].addDoc(object)
+}
+
+func (i *FileIndex) deleteItem(idxName string, doc string) error {
+	i.m.Lock()
+	defer i.m.Unlock()
+	i.updated = true
+	if _, found := i.idxmap[idxName]; !found {
+		err := fmt.Errorf("Index collection %s not found", idxName)
+		return err
+	}
+	i.idxmap[idxName].delDoc(doc)
+	return nil
+}
+
+func (i *FileIndex) search(idx string, term string, notop bool) (map[string]*Document, error) {
+	i.m.RLock()
+	defer i.m.RUnlock()
+	idc, found := i.idxmap[idx]
+	if !found {
+		err := fmt.Errorf("I don't know how to search for %s data objects.", idx)
+		return nil, err
+	}
+	// Special case - if term is '*:*', just return all of the keys
+	if term == "*:*" {
+		return idc.allDocs(), nil
+	}
+	results, err := idc.searchCollection(term, notop)
+	return results, err
+}
+
+func (i *FileIndex) searchText(idx string, term string, notop bool) (map[string]*Document, error) {
+	i.m.RLock()
+	defer i.m.RUnlock()
+	idc, found := i.idxmap[idx]
+	if !found {
+		err := fmt.Errorf("I don't know how to search for %s data objects.", idx)
+		return nil, err
+	}
+	results, err := idc.searchTextCollection(term, notop)
+	return results, err
+}
+
+func (i *FileIndex) searchRange(idx string, field string, start string, end string, inclusive bool) (map[string]*Document, error) {
+	i.m.RLock()
+	defer i.m.RUnlock()
+	idc, found := i.idxmap[idx]
+	if !found {
+		err := fmt.Errorf("I don't know how to search for %s data objects.", idx)
+		return nil, err
+	}
+	results, err := idc.searchRange(field, start, end, inclusive)
+	return results, err
+}
+
+func (i *FileIndex) endpoints() []string {
+	i.m.RLock()
+	defer i.m.RUnlock()
+
+	endpoints := make([]string, len(i.idxmap))
+	n := 0
+	for k := range i.idxmap {
+		endpoints[n] = k
+		n++
+	}
+
+	sort.Strings(endpoints)
+	return endpoints
+}
+
+func (i *FileIndex) makeDefaultCollections() {
+	defaults := [...]string{"client", "environment", "node", "role"}
+	i.m.Lock()
+	defer i.m.Unlock()
+	i.updated = true
+	i.idxmap = make(map[string]IndexCollection)
+	for _, d := range defaults {
+		i.createCollection(d)
+	}
+}
+
+/* IdxCollection methods */
+
+func (ic *IdxCollection) addDoc(object Indexable) {
+	ic.m.Lock()
+	if _, found := ic.docs[object.DocID()]; !found {
+		ic.docs[object.DocID()] = new(IdxDoc)
+	}
+	ic.m.Unlock()
+	ic.m.RLock()
+	defer ic.m.RUnlock()
+	ic.docs[object.DocID()].update(object)
+}
+
+func (ic *IdxCollection) delDoc(doc string) {
+	ic.m.Lock()
+	defer ic.m.Unlock()
+
+	delete(ic.docs, doc)
+}
+
+/* Search for an exact key/value match */
+func (ic *IdxCollection) searchCollection(term string, notop bool) (map[string]*Document, error) {
+	results := make(map[string]*Document)
+	ic.m.RLock()
+	defer ic.m.RUnlock()
+	l := len(ic.docs)
+	errCh := make(chan error, l)
+	resCh := make(chan *searchRes, l)
+	for k, v := range ic.docs {
+		go func(k string, v *IdxDoc) {
+			m, err := v.Examine(term)
+			if err != nil {
+				errCh <- err
+				resCh <- nil
+			} else {
+				errCh <- nil
+				if (m && !notop) || (!m && notop) {
+					r := &searchRes{k, v}
+					resCh <- r
+				} else {
+					resCh <- nil
+				}
+			}
+		}(k, v)
+	}
+	for i := 0; i < l; i++ {
+		e := <-errCh
+		if e != nil {
+			return nil, e
+		}
+	}
+	for i := 0; i < l; i++ {
+		r := <-resCh
+		if r != nil {
+			doc := Document(r.doc)
+			results[r.key] = &doc
+		}
+	}
+	rsafe := safeSearchResults(results)
+	return rsafe, nil
+}
+
+func (ic *IdxCollection) searchTextCollection(term string, notop bool) (map[string]*Document, error) {
+	results := make(map[string]*Document)
+	ic.m.RLock()
+	defer ic.m.RUnlock()
+	l := len(ic.docs)
+	errCh := make(chan error, l)
+	resCh := make(chan *searchRes, l)
+	for k, v := range ic.docs {
+		go func(k string, v *IdxDoc) {
+			m, err := v.TextSearch(term)
+			if err != nil {
+				errCh <- err
+				resCh <- nil
+			} else {
+				errCh <- nil
+				if (m && !notop) || (!m && notop) {
+					r := &searchRes{k, v}
+					logger.Debugf("Adding result %s to channel", k)
+					resCh <- r
+				} else {
+					resCh <- nil
+				}
+			}
+		}(k, v)
+	}
+	for i := 0; i < l; i++ {
+		e := <-errCh
+		if e != nil {
+			return nil, e
+		}
+	}
+	for i := 0; i < l; i++ {
+		r := <-resCh
+		if r != nil {
+			logger.Debugf("adding result")
+			doc := Document(r.doc)
+			results[r.key] = &doc
+		}
+	}
+	rsafe := safeSearchResults(results)
+	return rsafe, nil
+}
+
+func (ic *IdxCollection) searchRange(field string, start string, end string, inclusive bool) (map[string]*Document, error) {
+	results := make(map[string]*Document)
+	ic.m.RLock()
+	defer ic.m.RUnlock()
+	l := len(ic.docs)
+	errCh := make(chan error, l)
+	resCh := make(chan *searchRes, l)
+	for k, v := range ic.docs {
+		go func(k string, v *IdxDoc) {
+			m, err := v.RangeSearch(field, start, end, inclusive)
+			if err != nil {
+				errCh <- err
+				resCh <- nil
+			} else {
+				errCh <- nil
+				if m {
+					r := &searchRes{k, v}
+					logger.Debugf("Adding result %s to channel", k)
+					resCh <- r
+				} else {
+					resCh <- nil
+				}
+			}
+		}(k, v)
+	}
+	for i := 0; i < l; i++ {
+		e := <-errCh
+		if e != nil {
+			return nil, e
+		}
+	}
+	for i := 0; i < l; i++ {
+		r := <-resCh
+		if r != nil {
+			logger.Debugf("adding result")
+			doc := Document(r.doc)
+			results[r.key] = &doc
+		}
+	}
+	rsafe := safeSearchResults(results)
+	return rsafe, nil
+}
+
+func safeSearchResults(results map[string]*Document) map[string]*Document {
+	rsafe := make(map[string]*Document, len(results))
+	for k, v := range results {
+		j := &v
+		rsafe[k] = *j
+	}
+	return rsafe
+}
+
+func (ic *IdxCollection) allDocs() map[string]*Document {
+	docs := make(map[string]*Document, len(ic.docs))
+
+	for k, v := range ic.docs {
+		doc := Document(v)
+		docs[k] = &doc
+	}
+
+	return docs
+}
+
+
+/* IdxDoc methods */
+
+func (idoc *IdxDoc) update(object Indexable) {
+	idoc.m.Lock()
+	defer idoc.m.Unlock()
+	flattened := object.Flatten()
+	flatText := strings.Join(flattened, "\n")
+	/* recover from horrific trie errors that seem to happen with really
+	 * big values. :-/ */
+	defer func() {
+		if e := recover(); e != nil {
+			logger.Errorf("There was a problem creating the trie: %s", fmt.Sprintln(e))
+		}
+	}()
+	trie, err := gtrie.Create(flattened)
+	if err != nil {
+		logger.Errorf(err.Error())
+	} else {
+		var err error
+		idoc.trie, err = compressTrie(trie)
+		if err != nil {
+			panic(err)
+		}
+		idoc.docText, err = compressText(flatText)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// Examine searches a document, determining if it needs to do a search for an
+// exact term or a regexp search.
+func (idoc *IdxDoc) Examine(term string) (bool, error) {
+	idoc.m.RLock()
+	defer idoc.m.RUnlock()
+
+	r := regexp.MustCompile(`\*|\?`)
+	if r.MatchString(term) {
+		m, err := idoc.regexSearch(term)
+		return m, err
+	}
+	m, err := idoc.exactSearch(term)
+	if err != nil {
+		return false, err
+	}
+	return m, nil
+}
+
+// TextSearch performs a text search of an index document.
+func (idoc *IdxDoc) TextSearch(term string) (bool, error) {
+	if term[0] == '*' || term[0] == '?' {
+		err := fmt.Errorf("Can't start a term with a wildcard character")
+		return false, err
+	}
+	term = strings.Replace(term, "*", ".*", -1)
+	term = strings.Replace(term, "?", ".?", -1)
+	re := fmt.Sprintf("(?m):%s$", term)
+	reComp, err := regexp.Compile(re)
+	if err != nil {
+		return false, err
+	}
+	idoc.m.RLock()
+	defer idoc.m.RUnlock()
+	docText, err := decompressText(idoc.docText)
+	if err != nil {
+		return false, err
+	}
+	m := reComp.MatchString(docText)
+	return m, nil
+}
+
+// RangeSearch searches for a range of values.
+func (idoc *IdxDoc) RangeSearch(field string, start string, end string, inclusive bool) (bool, error) {
+	// The parser should catch a lot of possible errors, happily
+
+	// "*" is permitted as a range that indicates anything bigger or smaller
+	// than the other range, depending
+	wildStart := false
+	wildEnd := false
+	if start == "*" {
+		wildStart = true
+	}
+	if end == "*" {
+		wildEnd = true
+	}
+	if wildStart && wildEnd {
+		err := fmt.Errorf("you can't have both start and end be wild in a range search, sadly")
+		return false, err
+	}
+	idoc.m.RLock()
+	defer idoc.m.RUnlock()
+	key := fmt.Sprintf("%s:", field)
+	trie, err := decompressTrie(idoc.trie)
+	if err != nil {
+		return false, err
+	}
+	if n, _ := trie.HasPrefix(key); n != nil {
+		kids := n.ChildKeys()
+		for _, child := range kids {
+			if inclusive {
+				if wildStart {
+					if child <= end {
+						return true, nil
+					}
+				} else if wildEnd {
+					if child >= start {
+						return true, nil
+					}
+				} else {
+					if child >= start && child <= end {
+						return true, nil
+					}
+				}
+			} else {
+				if wildStart {
+					if child < end {
+						return true, nil
+					}
+				} else if wildEnd {
+					if child > start {
+						return true, nil
+					}
+				} else {
+					if child > start && child < end {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func (idoc *IdxDoc) exactSearch(term string) (bool, error) {
+	trie, err := decompressTrie(idoc.trie)
+	if err != nil {
+		return false, err
+	}
+	return trie.Accepts(term), nil
+}
+
+func (idoc *IdxDoc) regexSearch(reTerm string) (bool, error) {
+	z := strings.SplitN(reTerm, ":", 2)
+	key := fmt.Sprintf("%s:", z[0])
+	re := z[1]
+	/* Must add . before any * or ? in the regexp first. Taking the easy way
+	 * out and using strings.Replace. */
+	re = strings.Replace(re, "*", ".*", -1)
+	re = strings.Replace(re, "?", ".?", -1)
+	reComp, err := regexp.Compile(re)
+	if err != nil {
+		return false, err
+	}
+	/* What would be better would be to fetch all of the parts of the key
+	 * before the regexp part starts. Hmmm. */
+	trie, err := decompressTrie(idoc.trie)
+	if err != nil {
+		return false, err
+	}
+	if n, _ := trie.HasPrefix(key); n != nil {
+		kids := n.ChildKeys()
+		for _, c := range kids {
+			if reComp.MatchString(c) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+
+
+/* gob encoding functions for the index */
+
+func (i *FileIndex) GobEncode() ([]byte, error) {
+	w := new(bytes.Buffer)
+	encoder := gob.NewEncoder(w)
+	i.m.RLock()
+	defer i.m.RUnlock()
+	err := encoder.Encode(i.idxmap)
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func (i *FileIndex) GobDecode(buf []byte) error {
+	r := bytes.NewBuffer(buf)
+	decoder := gob.NewDecoder(r)
+	return decoder.Decode(&i.idxmap)
+}
+
+func (ic *IdxCollection) GobEncode() ([]byte, error) {
+	w := new(bytes.Buffer)
+	encoder := gob.NewEncoder(w)
+	ic.m.RLock()
+	defer ic.m.RUnlock()
+	err := encoder.Encode(ic.docs)
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func (ic *IdxCollection) GobDecode(buf []byte) error {
+	r := bytes.NewBuffer(buf)
+	decoder := gob.NewDecoder(r)
+	return decoder.Decode(&ic.docs)
+}
+
+func (idoc *IdxDoc) GobEncode() ([]byte, error) {
+	w := new(bytes.Buffer)
+	encoder := gob.NewEncoder(w)
+	idoc.m.RLock()
+	defer idoc.m.RUnlock()
+	err := encoder.Encode(idoc.trie)
+	if err != nil {
+		return nil, err
+	}
+	err = encoder.Encode(idoc.docText)
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func (idoc *IdxDoc) GobDecode(buf []byte) error {
+	r := bytes.NewBuffer(buf)
+	decoder := gob.NewDecoder(r)
+	err := decoder.Decode(&idoc.trie)
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(&idoc.docText)
+}
+
+func (i *FileIndex) save() error {
+	idxFile := i.file
+	if idxFile == "" {
+		err := fmt.Errorf("Yikes! Cannot save index to disk because no file was specified.")
+		return err
+	}
+	if !i.updated {
+		return nil
+	}
+	logger.Infof("Index has changed, saving to disk")
+	fp, err := ioutil.TempFile(path.Dir(idxFile), "idx-build")
+	if err != nil {
+		return err
+	}
+	zfp := zlib.NewWriter(fp)
+	i.m.RLock()
+	defer i.m.RUnlock()
+	i.updated = false
+	enc := gob.NewEncoder(zfp)
+	err = enc.Encode(i)
+	zfp.Close()
+	if err != nil {
+		fp.Close()
+		return err
+	}
+	err = fp.Close()
+	if err != nil {
+		return err
+	}
+	return os.Rename(fp.Name(), idxFile)
+}
+
+func (i *FileIndex) load() error {
+	idxFile := i.file
+	if idxFile == "" {
+		err := fmt.Errorf("Yikes! Cannot load index from disk because no file was specified.")
+		return err
+	}
+	fp, err := os.Open(idxFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	zfp, zerr := zlib.NewReader(fp)
+	if zerr != nil {
+		fp.Close()
+		return zerr
+	}
+	dec := gob.NewDecoder(zfp)
+	err = dec.Decode(&i)
+	zfp.Close()
+	if err != nil {
+		fp.Close()
+		return err
+	}
+	return fp.Close()
+}
+
+func compressTrie(t *gtrie.Node) ([]byte, error) {
+	b := new(bytes.Buffer)
+	z := zlib.NewWriter(b)
+	err := msgp.Encode(z, t)
+	z.Close()
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func decompressTrie(buf []byte) (*gtrie.Node, error) {
+	b := bytes.NewBuffer(buf)
+	z, err := zlib.NewReader(b)
+	if err != nil {
+		return nil, err
+	}
+	t := new(gtrie.Node)
+	err = msgp.Decode(z, t)
+	err2 := z.Close()
+	if err != nil {
+		return nil, err
+	}
+	if err2 != nil {
+		return nil, err2
+	}
+	return t, nil
+}
+
+func compressText(t string) ([]byte, error) {
+	b := new(bytes.Buffer)
+	z := zlib.NewWriter(b)
+	_, err := z.Write([]byte(t))
+	z.Close()
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func decompressText(buf []byte) (string, error) {
+	b := bytes.NewBuffer(buf)
+	z, err := zlib.NewReader(b)
+	if err != nil {
+		return "", err
+	}
+	t, err := ioutil.ReadAll(z)
+	z.Close()
+	if err != nil {
+		return "", err
+	}
+	return string(t), nil
+}
+

--- a/indexer/file_index.go
+++ b/indexer/file_index.go
@@ -24,6 +24,15 @@ type FileIndex struct {
 	updated bool
 }
 
+type IndexCollection interface {
+	addDoc(Indexable)
+	delDoc(string)
+	allDocs() map[string]*Document
+	searchCollection(string, bool) (map[string]*Document, error)
+	searchTextCollection(string, bool) (map[string]*Document, error)
+	searchRange(string, string, string, bool) (map[string]*Document, error)
+}
+
 // IdxCollection holds a map of documents.
 type IdxCollection struct {
 	m    sync.RWMutex

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -43,7 +43,7 @@ type Index interface {
 	searchText(string, string, bool) (map[string]*Document, error)
 	searchRange(string, string, string, string, bool) (map[string]*Document, error)
 	endpoints() []string
-	makeDefaultCollections()
+	clear()
 	save() error
 	load() error
 }
@@ -58,7 +58,6 @@ func Initialize(config *config.Conf) {
 	fileindex.file = config.IndexFile
 
 	im := Index(fileindex)
-	im.makeDefaultCollections()
 	im.initialize()
 
 	indexMap = im
@@ -132,7 +131,7 @@ func LoadIndex() error {
 
 // ClearIndex of all collections and documents
 func ClearIndex() {
-	indexMap.makeDefaultCollections()
+	indexMap.clear()
 	return
 }
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -20,20 +20,8 @@
 package indexer
 
 import (
-	"bytes"
-	"compress/zlib"
-	"encoding/gob"
 	"fmt"
-	"github.com/ctdk/go-trie/gtrie"
-	"github.com/ctdk/goas/v2/logger"
-	"github.com/philhofer/msgp/msgp"
-	"io/ioutil"
-	"os"
-	"path"
-	"regexp"
-	"sort"
-	"strings"
-	"sync"
+	"github.com/ctdk/goiardi/config"
 )
 
 // Indexable is an interface that provides all the information necessary to
@@ -45,40 +33,51 @@ type Indexable interface {
 }
 
 // Index holds a map of document collections.
-type Index struct {
-	m       sync.RWMutex
-	idxmap  map[string]*IdxCollection
-	updated bool
+type Index interface {
+	initialize()
+	createCollection(string)
+	deleteCollection(string)
+	saveIndex(Indexable)
+	deleteItem(string, string) error
+	search(string, string, bool) (map[string]*Document, error)
+	searchText(string, string, bool) (map[string]*Document, error)
+	searchRange(string, string, string, string, bool) (map[string]*Document, error)
+	endpoints() []string
+	makeDefaultCollections()
+	save() error
+	load() error
 }
 
-// IdxCollection holds a map of documents.
-type IdxCollection struct {
-	m    sync.RWMutex
-	docs map[string]*IdxDoc
+type Document interface {
 }
 
-// IdxDoc is the indexed documents that are actually searched.
-type IdxDoc struct {
-	m       sync.RWMutex
-	trie    []byte
-	docText []byte
+type IndexCollection interface {
+	addDoc(Indexable)
+	delDoc(string)
+	allDocs() map[string]*Document
+	searchCollection(string, bool) (map[string]*Document, error)
+	searchTextCollection(string, bool) (map[string]*Document, error)
+	searchRange(string, string, string, bool) (map[string]*Document, error)
 }
 
-type searchRes struct {
-	key string
-	doc *IdxDoc
-}
+var indexMap Index
 
-/* Index methods */
+func Initialize(config *config.Conf) {
+	fileindex := new(FileIndex)
+	fileindex.file = config.IndexFile
+
+	im := Index(fileindex)
+	im.makeDefaultCollections()
+	im.initialize()
+
+	indexMap = im
+}
 
 // Create a new index collection.
 
 // CreateNewCollection creates an index for data bags when they are created,
 // rather than when the first data bag item is uploaded
 func CreateNewCollection(idxName string) {
-	indexMap.m.Lock()
-	defer indexMap.m.Unlock()
-	indexMap.updated = true
 	indexMap.createCollection(idxName)
 }
 
@@ -100,442 +99,6 @@ func DeleteItemFromCollection(idxName string, doc string) error {
 	return err
 }
 
-func (i *Index) createCollection(idxName string) {
-	if _, ok := i.idxmap[idxName]; !ok {
-		i.idxmap[idxName] = new(IdxCollection)
-		i.idxmap[idxName].docs = make(map[string]*IdxDoc)
-	}
-}
-
-func (i *Index) deleteCollection(idxName string) {
-	i.m.Lock()
-	defer i.m.Unlock()
-	i.updated = true
-	delete(i.idxmap, idxName)
-}
-
-func (i *Index) saveIndex(object Indexable) {
-	/* Have to check to see if data bag indexes exist */
-	i.m.Lock()
-	defer i.m.Unlock()
-	i.updated = true
-	if _, found := i.idxmap[object.Index()]; !found {
-		i.createCollection(object.Index())
-	}
-	i.idxmap[object.Index()].addDoc(object)
-}
-
-func (i *Index) deleteItem(idxName string, doc string) error {
-	i.m.Lock()
-	defer i.m.Unlock()
-	i.updated = true
-	if _, found := i.idxmap[idxName]; !found {
-		err := fmt.Errorf("Index collection %s not found", idxName)
-		return err
-	}
-	i.idxmap[idxName].delDoc(doc)
-	return nil
-}
-
-func (i *Index) search(idx string, term string, notop bool) (map[string]*IdxDoc, error) {
-	i.m.RLock()
-	defer i.m.RUnlock()
-	idc, found := i.idxmap[idx]
-	if !found {
-		err := fmt.Errorf("I don't know how to search for %s data objects.", idx)
-		return nil, err
-	}
-	// Special case - if term is '*:*', just return all of the keys
-	if term == "*:*" {
-		return idc.docs, nil
-	}
-	results, err := idc.searchCollection(term, notop)
-	return results, err
-}
-
-func (i *Index) searchText(idx string, term string, notop bool) (map[string]*IdxDoc, error) {
-	i.m.RLock()
-	defer i.m.RUnlock()
-	idc, found := i.idxmap[idx]
-	if !found {
-		err := fmt.Errorf("I don't know how to search for %s data objects.", idx)
-		return nil, err
-	}
-	results, err := idc.searchTextCollection(term, notop)
-	return results, err
-}
-
-func (i *Index) searchRange(idx string, field string, start string, end string, inclusive bool) (map[string]*IdxDoc, error) {
-	i.m.RLock()
-	defer i.m.RUnlock()
-	idc, found := i.idxmap[idx]
-	if !found {
-		err := fmt.Errorf("I don't know how to search for %s data objects.", idx)
-		return nil, err
-	}
-	results, err := idc.searchRange(field, start, end, inclusive)
-	return results, err
-}
-
-func (i *Index) endpoints() []string {
-	i.m.RLock()
-	defer i.m.RUnlock()
-
-	endpoints := make([]string, len(i.idxmap))
-	n := 0
-	for k := range i.idxmap {
-		endpoints[n] = k
-		n++
-	}
-
-	sort.Strings(endpoints)
-	return endpoints
-}
-
-/* IdxCollection methods */
-
-func (ic *IdxCollection) addDoc(object Indexable) {
-	ic.m.Lock()
-	if _, found := ic.docs[object.DocID()]; !found {
-		ic.docs[object.DocID()] = new(IdxDoc)
-	}
-	ic.m.Unlock()
-	ic.m.RLock()
-	defer ic.m.RUnlock()
-	ic.docs[object.DocID()].update(object)
-}
-
-func (ic *IdxCollection) delDoc(doc string) {
-	ic.m.Lock()
-	defer ic.m.Unlock()
-
-	delete(ic.docs, doc)
-}
-
-/* Search for an exact key/value match */
-func (ic *IdxCollection) searchCollection(term string, notop bool) (map[string]*IdxDoc, error) {
-	results := make(map[string]*IdxDoc)
-	ic.m.RLock()
-	defer ic.m.RUnlock()
-	l := len(ic.docs)
-	errCh := make(chan error, l)
-	resCh := make(chan *searchRes, l)
-	for k, v := range ic.docs {
-		go func(k string, v *IdxDoc) {
-			m, err := v.Examine(term)
-			if err != nil {
-				errCh <- err
-				resCh <- nil
-			} else {
-				errCh <- nil
-				if (m && !notop) || (!m && notop) {
-					r := &searchRes{k, v}
-					resCh <- r
-				} else {
-					resCh <- nil
-				}
-			}
-		}(k, v)
-	}
-	for i := 0; i < l; i++ {
-		e := <-errCh
-		if e != nil {
-			return nil, e
-		}
-	}
-	for i := 0; i < l; i++ {
-		r := <-resCh
-		if r != nil {
-			results[r.key] = r.doc
-		}
-	}
-	rsafe := safeSearchResults(results)
-	return rsafe, nil
-}
-
-func (ic *IdxCollection) searchTextCollection(term string, notop bool) (map[string]*IdxDoc, error) {
-	results := make(map[string]*IdxDoc)
-	ic.m.RLock()
-	defer ic.m.RUnlock()
-	l := len(ic.docs)
-	errCh := make(chan error, l)
-	resCh := make(chan *searchRes, l)
-	for k, v := range ic.docs {
-		go func(k string, v *IdxDoc) {
-			m, err := v.TextSearch(term)
-			if err != nil {
-				errCh <- err
-				resCh <- nil
-			} else {
-				errCh <- nil
-				if (m && !notop) || (!m && notop) {
-					r := &searchRes{k, v}
-					logger.Debugf("Adding result %s to channel", k)
-					resCh <- r
-				} else {
-					resCh <- nil
-				}
-			}
-		}(k, v)
-	}
-	for i := 0; i < l; i++ {
-		e := <-errCh
-		if e != nil {
-			return nil, e
-		}
-	}
-	for i := 0; i < l; i++ {
-		r := <-resCh
-		if r != nil {
-			logger.Debugf("adding result")
-			results[r.key] = r.doc
-		}
-	}
-	rsafe := safeSearchResults(results)
-	return rsafe, nil
-}
-
-func (ic *IdxCollection) searchRange(field string, start string, end string, inclusive bool) (map[string]*IdxDoc, error) {
-	results := make(map[string]*IdxDoc)
-	ic.m.RLock()
-	defer ic.m.RUnlock()
-	l := len(ic.docs)
-	errCh := make(chan error, l)
-	resCh := make(chan *searchRes, l)
-	for k, v := range ic.docs {
-		go func(k string, v *IdxDoc) {
-			m, err := v.RangeSearch(field, start, end, inclusive)
-			if err != nil {
-				errCh <- err
-				resCh <- nil
-			} else {
-				errCh <- nil
-				if m {
-					r := &searchRes{k, v}
-					logger.Debugf("Adding result %s to channel", k)
-					resCh <- r
-				} else {
-					resCh <- nil
-				}
-			}
-		}(k, v)
-	}
-	for i := 0; i < l; i++ {
-		e := <-errCh
-		if e != nil {
-			return nil, e
-		}
-	}
-	for i := 0; i < l; i++ {
-		r := <-resCh
-		if r != nil {
-			logger.Debugf("adding result")
-			results[r.key] = r.doc
-		}
-	}
-	rsafe := safeSearchResults(results)
-	return rsafe, nil
-}
-
-func safeSearchResults(results map[string]*IdxDoc) map[string]*IdxDoc {
-	rsafe := make(map[string]*IdxDoc, len(results))
-	for k, v := range results {
-		j := &v
-		rsafe[k] = *j
-	}
-	return rsafe
-}
-
-/* IdxDoc methods */
-func (idoc *IdxDoc) update(object Indexable) {
-	idoc.m.Lock()
-	defer idoc.m.Unlock()
-	flattened := object.Flatten()
-	flatText := strings.Join(flattened, "\n")
-	/* recover from horrific trie errors that seem to happen with really
-	 * big values. :-/ */
-	defer func() {
-		if e := recover(); e != nil {
-			logger.Errorf("There was a problem creating the trie: %s", fmt.Sprintln(e))
-		}
-	}()
-	trie, err := gtrie.Create(flattened)
-	if err != nil {
-		logger.Errorf(err.Error())
-	} else {
-		var err error
-		idoc.trie, err = compressTrie(trie)
-		if err != nil {
-			panic(err)
-		}
-		idoc.docText, err = compressText(flatText)
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
-// Examine searches a document, determining if it needs to do a search for an
-// exact term or a regexp search.
-func (idoc *IdxDoc) Examine(term string) (bool, error) {
-	idoc.m.RLock()
-	defer idoc.m.RUnlock()
-
-	r := regexp.MustCompile(`\*|\?`)
-	if r.MatchString(term) {
-		m, err := idoc.regexSearch(term)
-		return m, err
-	}
-	m, err := idoc.exactSearch(term)
-	if err != nil {
-		return false, err
-	}
-	return m, nil
-}
-
-// TextSearch performs a text search of an index document.
-func (idoc *IdxDoc) TextSearch(term string) (bool, error) {
-	if term[0] == '*' || term[0] == '?' {
-		err := fmt.Errorf("Can't start a term with a wildcard character")
-		return false, err
-	}
-	term = strings.Replace(term, "*", ".*", -1)
-	term = strings.Replace(term, "?", ".?", -1)
-	re := fmt.Sprintf("(?m):%s$", term)
-	reComp, err := regexp.Compile(re)
-	if err != nil {
-		return false, err
-	}
-	idoc.m.RLock()
-	defer idoc.m.RUnlock()
-	docText, err := decompressText(idoc.docText)
-	if err != nil {
-		return false, err
-	}
-	m := reComp.MatchString(docText)
-	return m, nil
-}
-
-// RangeSearch searches for a range of values.
-func (idoc *IdxDoc) RangeSearch(field string, start string, end string, inclusive bool) (bool, error) {
-	// The parser should catch a lot of possible errors, happily
-
-	// "*" is permitted as a range that indicates anything bigger or smaller
-	// than the other range, depending
-	wildStart := false
-	wildEnd := false
-	if start == "*" {
-		wildStart = true
-	}
-	if end == "*" {
-		wildEnd = true
-	}
-	if wildStart && wildEnd {
-		err := fmt.Errorf("you can't have both start and end be wild in a range search, sadly")
-		return false, err
-	}
-	idoc.m.RLock()
-	defer idoc.m.RUnlock()
-	key := fmt.Sprintf("%s:", field)
-	trie, err := decompressTrie(idoc.trie)
-	if err != nil {
-		return false, err
-	}
-	if n, _ := trie.HasPrefix(key); n != nil {
-		kids := n.ChildKeys()
-		for _, child := range kids {
-			if inclusive {
-				if wildStart {
-					if child <= end {
-						return true, nil
-					}
-				} else if wildEnd {
-					if child >= start {
-						return true, nil
-					}
-				} else {
-					if child >= start && child <= end {
-						return true, nil
-					}
-				}
-			} else {
-				if wildStart {
-					if child < end {
-						return true, nil
-					}
-				} else if wildEnd {
-					if child > start {
-						return true, nil
-					}
-				} else {
-					if child > start && child < end {
-						return true, nil
-					}
-				}
-			}
-		}
-	}
-	return false, nil
-}
-
-func (idoc *IdxDoc) exactSearch(term string) (bool, error) {
-	trie, err := decompressTrie(idoc.trie)
-	if err != nil {
-		return false, err
-	}
-	return trie.Accepts(term), nil
-}
-
-func (idoc *IdxDoc) regexSearch(reTerm string) (bool, error) {
-	z := strings.SplitN(reTerm, ":", 2)
-	key := fmt.Sprintf("%s:", z[0])
-	re := z[1]
-	/* Must add . before any * or ? in the regexp first. Taking the easy way
-	 * out and using strings.Replace. */
-	re = strings.Replace(re, "*", ".*", -1)
-	re = strings.Replace(re, "?", ".?", -1)
-	reComp, err := regexp.Compile(re)
-	if err != nil {
-		return false, err
-	}
-	/* What would be better would be to fetch all of the parts of the key
-	 * before the regexp part starts. Hmmm. */
-	trie, err := decompressTrie(idoc.trie)
-	if err != nil {
-		return false, err
-	}
-	if n, _ := trie.HasPrefix(key); n != nil {
-		kids := n.ChildKeys()
-		for _, c := range kids {
-			if reComp.MatchString(c) {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
-}
-
-var indexMap = initializeIndex()
-
-func initializeIndex() *Index {
-	/* We always want these indices at least. */
-	im := new(Index)
-	im.makeDefaultCollections()
-
-	return im
-}
-
-func (i *Index) makeDefaultCollections() {
-	defaults := [...]string{"client", "environment", "node", "role"}
-	i.m.Lock()
-	defer i.m.Unlock()
-	i.updated = true
-	i.idxmap = make(map[string]*IdxCollection)
-	for _, d := range defaults {
-		i.createCollection(d)
-	}
-}
-
 // IndexObj processes and adds an object to the index.
 func IndexObj(object Indexable) {
 	go indexMap.saveIndex(object)
@@ -543,19 +106,19 @@ func IndexObj(object Indexable) {
 
 // SearchIndex searches for a string in the given index. Returns a slice of
 // names of matching objects, or an error on failure.
-func SearchIndex(idxName string, term string, notop bool) (map[string]*IdxDoc, error) {
+func SearchIndex(idxName string, term string, notop bool) (map[string]*Document, error) {
 	res, err := indexMap.search(idxName, term, notop)
 	return res, err
 }
 
 // SearchText performs a full-ish text search of the index.
-func SearchText(idxName string, term string, notop bool) (map[string]*IdxDoc, error) {
+func SearchText(idxName string, term string, notop bool) (map[string]*Document, error) {
 	res, err := indexMap.searchText(idxName, term, notop)
 	return res, err
 }
 
 // SearchRange performs a range search on the given index.
-func SearchRange(idxName string, field string, start string, end string, inclusive bool) (map[string]*IdxDoc, error) {
+func SearchRange(idxName string, field string, start string, end string, inclusive bool) (map[string]*Document, error) {
 	res, err := indexMap.searchRange(idxName, field, start, end, inclusive)
 	return res, err
 }
@@ -567,135 +130,13 @@ func Endpoints() []string {
 }
 
 // SaveIndex saves the index files to disk.
-func SaveIndex(idxFile string) error {
-	return indexMap.save(idxFile)
+func SaveIndex() error {
+	return indexMap.save()
 }
 
 // LoadIndex loads index files from disk.
-func LoadIndex(idxFile string) error {
-	return indexMap.load(idxFile)
-}
-
-/* gob encoding functions for the index */
-
-func (i *Index) GobEncode() ([]byte, error) {
-	w := new(bytes.Buffer)
-	encoder := gob.NewEncoder(w)
-	i.m.RLock()
-	defer i.m.RUnlock()
-	err := encoder.Encode(i.idxmap)
-	if err != nil {
-		return nil, err
-	}
-	return w.Bytes(), nil
-}
-
-func (i *Index) GobDecode(buf []byte) error {
-	r := bytes.NewBuffer(buf)
-	decoder := gob.NewDecoder(r)
-	return decoder.Decode(&i.idxmap)
-}
-
-func (ic *IdxCollection) GobEncode() ([]byte, error) {
-	w := new(bytes.Buffer)
-	encoder := gob.NewEncoder(w)
-	ic.m.RLock()
-	defer ic.m.RUnlock()
-	err := encoder.Encode(ic.docs)
-	if err != nil {
-		return nil, err
-	}
-	return w.Bytes(), nil
-}
-
-func (ic *IdxCollection) GobDecode(buf []byte) error {
-	r := bytes.NewBuffer(buf)
-	decoder := gob.NewDecoder(r)
-	return decoder.Decode(&ic.docs)
-}
-
-func (idoc *IdxDoc) GobEncode() ([]byte, error) {
-	w := new(bytes.Buffer)
-	encoder := gob.NewEncoder(w)
-	idoc.m.RLock()
-	defer idoc.m.RUnlock()
-	err := encoder.Encode(idoc.trie)
-	if err != nil {
-		return nil, err
-	}
-	err = encoder.Encode(idoc.docText)
-	if err != nil {
-		return nil, err
-	}
-	return w.Bytes(), nil
-}
-
-func (idoc *IdxDoc) GobDecode(buf []byte) error {
-	r := bytes.NewBuffer(buf)
-	decoder := gob.NewDecoder(r)
-	err := decoder.Decode(&idoc.trie)
-	if err != nil {
-		return err
-	}
-	return decoder.Decode(&idoc.docText)
-}
-
-func (i *Index) save(idxFile string) error {
-	if idxFile == "" {
-		err := fmt.Errorf("Yikes! Cannot save index to disk because no file was specified.")
-		return err
-	}
-	if !i.updated {
-		return nil
-	}
-	logger.Infof("Index has changed, saving to disk")
-	fp, err := ioutil.TempFile(path.Dir(idxFile), "idx-build")
-	if err != nil {
-		return err
-	}
-	zfp := zlib.NewWriter(fp)
-	i.m.RLock()
-	defer i.m.RUnlock()
-	i.updated = false
-	enc := gob.NewEncoder(zfp)
-	err = enc.Encode(i)
-	zfp.Close()
-	if err != nil {
-		fp.Close()
-		return err
-	}
-	err = fp.Close()
-	if err != nil {
-		return err
-	}
-	return os.Rename(fp.Name(), idxFile)
-}
-
-func (i *Index) load(idxFile string) error {
-	if idxFile == "" {
-		err := fmt.Errorf("Yikes! Cannot load index from disk because no file was specified.")
-		return err
-	}
-	fp, err := os.Open(idxFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	zfp, zerr := zlib.NewReader(fp)
-	if zerr != nil {
-		fp.Close()
-		return zerr
-	}
-	dec := gob.NewDecoder(zfp)
-	err = dec.Decode(&i)
-	zfp.Close()
-	if err != nil {
-		fp.Close()
-		return err
-	}
-	return fp.Close()
+func LoadIndex() error {
+	return indexMap.load()
 }
 
 // ClearIndex of all collections and documents
@@ -712,58 +153,4 @@ func ReIndex(objects []Indexable) error {
 	// We really ought to be able to return from an error, but at the moment
 	// there aren't any ways it does so in the index save bits.
 	return nil
-}
-
-func compressTrie(t *gtrie.Node) ([]byte, error) {
-	b := new(bytes.Buffer)
-	z := zlib.NewWriter(b)
-	err := msgp.Encode(z, t)
-	z.Close()
-	if err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
-}
-
-func decompressTrie(buf []byte) (*gtrie.Node, error) {
-	b := bytes.NewBuffer(buf)
-	z, err := zlib.NewReader(b)
-	if err != nil {
-		return nil, err
-	}
-	t := new(gtrie.Node)
-	err = msgp.Decode(z, t)
-	err2 := z.Close()
-	if err != nil {
-		return nil, err
-	}
-	if err2 != nil {
-		return nil, err2
-	}
-	return t, nil
-}
-
-func compressText(t string) ([]byte, error) {
-	b := new(bytes.Buffer)
-	z := zlib.NewWriter(b)
-	_, err := z.Write([]byte(t))
-	z.Close()
-	if err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
-}
-
-func decompressText(buf []byte) (string, error) {
-	b := bytes.NewBuffer(buf)
-	z, err := zlib.NewReader(b)
-	if err != nil {
-		return "", err
-	}
-	t, err := ioutil.ReadAll(z)
-	z.Close()
-	if err != nil {
-		return "", err
-	}
-	return string(t), nil
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -51,15 +51,6 @@ type Index interface {
 type Document interface {
 }
 
-type IndexCollection interface {
-	addDoc(Indexable)
-	delDoc(string)
-	allDocs() map[string]*Document
-	searchCollection(string, bool) (map[string]*Document, error)
-	searchTextCollection(string, bool) (map[string]*Document, error)
-	searchRange(string, string, string, bool) (map[string]*Document, error)
-}
-
 var indexMap Index
 
 func Initialize(config *config.Conf) {

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -29,7 +29,7 @@ import (
 type Indexable interface {
 	DocID() string
 	Index() string
-	Flatten() []string
+	Flatten() map[string]interface{}
 }
 
 // Index holds a map of document collections.

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -54,10 +54,16 @@ type Document interface {
 var indexMap Index
 
 func Initialize(config *config.Conf) {
-	fileindex := new(FileIndex)
-	fileindex.file = config.IndexFile
+	var im Index
+	if config.UsePostgreSQL {
+		im = Index(new(PostgreSQLIndex))
+	} else {
+		fileindex := new(FileIndex)
+		fileindex.file = config.IndexFile
 
-	im := Index(fileindex)
+		im = Index(fileindex)
+	}
+
 	im.initialize()
 
 	indexMap = im

--- a/indexer/postgresql_index.go
+++ b/indexer/postgresql_index.go
@@ -1,0 +1,283 @@
+package indexer
+
+import (
+	"sort"
+	"github.com/ctdk/goiardi/datastore"
+	"github.com/ctdk/goas/v2/logger"
+	"strings"
+	"database/sql"
+	"regexp"
+)
+
+type PostgreSQLIndex struct {
+}
+
+
+func (i *PostgreSQLIndex) createCollection(idxName string) {
+	// nothing to do here
+}
+
+func (i *PostgreSQLIndex) deleteCollection(idxName string) {
+	logger.Debugf("Deleting index: %s", idxName)
+
+	switch idxName {
+		case "node":
+			i.deleteIndex("goiardi.node_search")
+		default:
+			logger.Errorf("unkown index: %s", idxName)
+	}
+
+}
+
+func (i *PostgreSQLIndex) saveIndex(object Indexable) {
+	switch object.Index() {
+		case "node":
+			i.indexNode(object)
+		default:
+			logger.Errorf("unkown index: %s", object.Index())
+	}
+}
+
+func (i *PostgreSQLIndex) deleteItem(idxName string, doc string) error {
+	switch idxName {
+		case "node":
+			params := make([]interface{}, 1)
+			params[0] = doc
+			return i.runInTransaction("DELETE FROM node_search WHERE name = $1", params)
+		default:
+			logger.Errorf("unkown index: %s", idxName)
+	}
+
+	return nil
+}
+
+func (i *PostgreSQLIndex) search(idx string, term string, notop bool) (map[string]*Document, error) {
+	parts := strings.SplitN(term, ":", 2)
+
+	if parts[0] == "*" {
+		parts[0] = "%"
+	}
+
+	r := regexp.MustCompile(`\*|\?`)
+
+	value := parts[1]
+	isWildcard := r.MatchString(value)
+	isPrefix := false
+	if isWildcard {
+		position := r.FindStringIndex(value)
+
+		isPrefix = position[1] == len(value)
+		if isPrefix {
+			//prefix search
+			value = value[0:len(value) - 1] + ":*"
+		} else {
+			value = value[0:position[1]]
+		}
+	}
+
+	sqlNot := ""
+	if notop {
+		sqlNot = "NOT"
+	}
+
+	results := make(map[string]*Document)
+
+	switch idx {
+		case "node":
+			sqlStmt := "SELECT ns.name, ns.value FROM goiardi.node_search ns WHERE ns.field LIKE $1 AND " + sqlNot + " ns.value @@ $2::tsquery"
+			params := make([]interface{}, 2)
+			params[0] = parts[0]
+			params[1] = value
+
+			values, err := queryPostgresIndex(sqlStmt, params)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return filterSearchResults(values, parts[1], isWildcard, isPrefix, notop)
+		default:
+			logger.Errorf("unkown index: %s", idx)
+	}
+
+	return results, nil
+}
+
+func (i *PostgreSQLIndex) searchText(idx string, term string, notop bool) (map[string]*Document, error) {
+	results := make(map[string]*Document)
+
+	return results, nil
+}
+
+func (i *PostgreSQLIndex) searchRange(idx string, field string, start string, end string, inclusive bool) (map[string]*Document, error) {
+	results := make(map[string]*Document)
+
+	return results, nil
+}
+
+func (i *PostgreSQLIndex) endpoints() []string {
+	endpoints := []string{"client", "environment", "node", "role"}
+
+	// todo query databag names later from index
+
+	sort.Strings(endpoints)
+	return endpoints
+}
+
+func (i *PostgreSQLIndex) clear() {
+	for _, index := range i.endpoints() {
+		i.deleteCollection(index)
+	}
+}
+
+func (i *PostgreSQLIndex) makeDefaultCollections() {
+	// nothing to do here
+}
+
+func (i *PostgreSQLIndex) initialize() {
+	// nothing to do here
+}
+
+func (i *PostgreSQLIndex) save() error {
+	// nothing to do here, every operation is saved instantly
+	return nil
+}
+
+func (i *PostgreSQLIndex) load() error {
+	// nothing to do here, every operation is saved instantly
+	return nil
+}
+
+func (i *PostgreSQLIndex) indexNode(object Indexable) {
+	fields := object.Flatten()
+
+	logger.Debugf("Inserting document into postgres node index: %s", object.DocID())
+
+	tx, nil := datastore.Dbh.Begin()
+	_, err := tx.Exec("DELETE FROM goiardi.node_search WHERE node_search.name = $1", object.DocID())
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+
+	for field_name, value := range fields {
+		switch value.(type) {
+			case []string:
+				value = strings.Join(value.([]string), " ")
+			default:
+		}
+		_, err := tx.Exec("INSERT INTO goiardi.node_search (name, field, value) VALUES($1, $2, $3)", object.DocID(), field_name, value)
+		if err != nil {
+			tx.Rollback()
+			logger.Errorf("Error inserting into postgres node index: %s", err)
+			return
+		}
+	}
+
+	tx.Commit()
+	logger.Debugf("Inserted document into postgres node index: %s", object.DocID())
+}
+
+func (i *PostgreSQLIndex) deleteIndex(tableName string) error {
+	return i.runInTransaction("DELETE FROM " + tableName, make([]interface{}, 0))
+}
+
+func (i *PostgreSQLIndex) runInTransaction(query string, params []interface{}) error {
+	tx, nil := datastore.Dbh.Begin()
+	_, err := tx.Exec(query, params...)
+	if err != nil {
+		tx.Rollback()
+		logger.Errorf("Failed to run query: %s %s", query, err)
+		return err
+	}
+	return tx.Commit()
+}
+
+func queryPostgresIndex(sqlStmt string, params []interface{}) (map[string]string, error) {
+	results := make(map[string]string)
+
+	stmt, err := datastore.Dbh.Prepare(sqlStmt)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	queryParams := make([]interface{}, len(params))
+	copy(queryParams, params[0:])
+
+	rows, qerr := stmt.Query(queryParams...)
+	defer rows.Close()
+
+	if qerr != nil {
+		if qerr == sql.ErrNoRows {
+			return results, nil
+		}
+		return nil, qerr
+	}
+	for rows.Next() {
+		var name string
+		var value string
+
+		err := rows.Scan(&name, &value)
+		if err != nil {
+			return nil, err
+		}
+
+		results[name] = value
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func filterSearchResults(values map[string]string, searchTerm string, isWildcard bool, isPrefix bool, notop bool) (map[string]*Document, error) {
+	results := make(map[string]*Document)
+
+	if (isWildcard && isPrefix) || !isWildcard {
+		for name, _ := range values {
+			results[name] = new(Document)
+		}
+	} else {
+		errCh := make(chan error, len(values))
+		resCh := make(chan *string, len(values))
+		for name, value := range values {
+			go func(name string, value string) {
+				term := searchTerm
+				term = strings.Replace(term, "*", ".*", -1)
+				term = strings.Replace(term, "?", ".{1,1}", -1)
+				reComp, err := regexp.Compile(term)
+
+				if err != nil {
+					errCh <- err
+					resCh <- nil
+				} else {
+					errCh <- nil
+
+					match := reComp.MatchString(value)
+					if (match && !notop) || (!match && notop) {
+						resCh <- &name
+					} else {
+						resCh <- nil
+					}
+				}
+			}(name, value)
+		}
+		for i := 0; i < len(values); i++ {
+			e := <-errCh
+			if e != nil {
+				return nil, e
+			}
+		}
+		for i := 0; i < len(values); i++ {
+			name := <-resCh
+			if name != nil {
+				results[*name] = new(Document)
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -319,10 +319,8 @@ func (n *Node) Index() string {
 }
 
 // Flatten a node for indexing.
-func (n *Node) Flatten() []string {
-	flatten := util.FlattenObj(n)
-	indexified := util.Indexify(flatten)
-	return indexified
+func (n *Node) Flatten() map[string]interface{} {
+	return util.FlattenObj(n)
 }
 
 // AllNodes returns all the nodes on the server

--- a/role/role.go
+++ b/role/role.go
@@ -280,10 +280,8 @@ func (r *Role) Index() string {
 }
 
 // Flatten a role so it's suitable for indexing.
-func (r *Role) Flatten() []string {
-	flatten := util.FlattenObj(r)
-	indexified := util.Indexify(flatten)
-	return indexified
+func (r *Role) Flatten() map[string]interface{} {
+	return util.FlattenObj(r)
 }
 
 // AllRoles returns all the roles on the server

--- a/search/parse.go
+++ b/search/parse.go
@@ -123,7 +123,7 @@ type SubQuery struct {
 // be able to implement to search the index.
 type Queryable interface {
 	// Search the index for the given term.
-	SearchIndex(string) (map[string]*indexer.IdxDoc, error)
+	SearchIndex(string) (map[string]*indexer.Document, error)
 	// Add an operator to this query chain link.
 	AddOp(Op)
 	// Get this query chain link's op.
@@ -150,10 +150,10 @@ type Queryable interface {
 
 type groupQueryHolder struct {
 	op  Op
-	res map[string]*indexer.IdxDoc
+	res map[string]*indexer.Document
 }
 
-func (q *BasicQuery) SearchIndex(idxName string) (map[string]*indexer.IdxDoc, error) {
+func (q *BasicQuery) SearchIndex(idxName string) (map[string]*indexer.Document, error) {
 	notop := false
 	if (q.term.mod == OpUnaryNot) || (q.term.mod == OpUnaryPro) {
 		notop = true
@@ -315,7 +315,7 @@ func (q *RangeQuery) AddFuzzParam(s string) {
 
 }
 
-func (q *GroupedQuery) SearchIndex(idxName string) (map[string]*indexer.IdxDoc, error) {
+func (q *GroupedQuery) SearchIndex(idxName string) (map[string]*indexer.Document, error) {
 	tmpRes := make([]groupQueryHolder, len(q.terms))
 	for i, v := range q.terms {
 		tmpRes[i].op = v.mod
@@ -331,8 +331,8 @@ func (q *GroupedQuery) SearchIndex(idxName string) (map[string]*indexer.IdxDoc, 
 		tmpRes[i].res = r
 	}
 	reqOp := false
-	res := make(map[string]*indexer.IdxDoc)
-	var req map[string]*indexer.IdxDoc
+	res := make(map[string]*indexer.Document)
+	var req map[string]*indexer.Document
 
 	// Merge the results, taking into account any + operators lurking about
 	for _, t := range tmpRes {
@@ -359,12 +359,12 @@ func (q *GroupedQuery) SearchIndex(idxName string) (map[string]*indexer.IdxDoc, 
 	return res, nil
 }
 
-func (q *RangeQuery) SearchIndex(idxName string) (map[string]*indexer.IdxDoc, error) {
+func (q *RangeQuery) SearchIndex(idxName string) (map[string]*indexer.Document, error) {
 	res, err := indexer.SearchRange(idxName, string(q.field), string(q.start), string(q.end), q.inclusive)
 	return res, err
 }
 
-func (q *SubQuery) SearchIndex(idxName string) (map[string]*indexer.IdxDoc, error) {
+func (q *SubQuery) SearchIndex(idxName string) (map[string]*indexer.Document, error) {
 	return nil, nil
 }
 

--- a/search/search.go
+++ b/search/search.go
@@ -34,7 +34,7 @@ import (
 type SolrQuery struct {
 	queryChain Queryable
 	idxName    string
-	docs       map[string]*indexer.IdxDoc
+	docs       map[string]*indexer.Document
 }
 
 // Search parses the given query string and search the given index for any
@@ -52,7 +52,7 @@ func Search(idx string, q string) ([]indexer.Indexable, error) {
 	}
 	qq.Execute()
 	qchain := qq.Evaluate()
-	d := make(map[string]*indexer.IdxDoc)
+	d := make(map[string]*indexer.Document)
 	solrQ := &SolrQuery{queryChain: qchain, idxName: idx, docs: d}
 
 	_, err := solrQ.execute()
@@ -64,11 +64,11 @@ func Search(idx string, q string) ([]indexer.Indexable, error) {
 	return objs, nil
 }
 
-func (sq *SolrQuery) execute() (map[string]*indexer.IdxDoc, error) {
+func (sq *SolrQuery) execute() (map[string]*indexer.Document, error) {
 	s := sq.queryChain
 	curOp := OpNotAnOp
 	for s != nil {
-		var r map[string]*indexer.IdxDoc
+		var r map[string]*indexer.Document
 		var err error
 		switch c := s.(type) {
 		case *SubQuery:
@@ -78,7 +78,7 @@ func (sq *SolrQuery) execute() (map[string]*indexer.IdxDoc, error) {
 				return nil, err
 			}
 			s = nend
-			d := make(map[string]*indexer.IdxDoc)
+			d := make(map[string]*indexer.Document)
 			nsq := &SolrQuery{queryChain: newq, idxName: sq.idxName, docs: d}
 			r, err = nsq.execute()
 		default:
@@ -94,7 +94,7 @@ func (sq *SolrQuery) execute() (map[string]*indexer.IdxDoc, error) {
 				sq.docs[k] = v
 			}
 		} else if curOp == OpBinAnd {
-			newRes := make(map[string]*indexer.IdxDoc, len(sq.docs)+len(r))
+			newRes := make(map[string]*indexer.Document, len(sq.docs)+len(r))
 			for k, v := range sq.docs {
 				if _, found := r[k]; found {
 					newRes[k] = v

--- a/sql-files/postgres-bundle/deploy/node_search.sql
+++ b/sql-files/postgres-bundle/deploy/node_search.sql
@@ -1,0 +1,23 @@
+-- Deploy node_search
+
+BEGIN;
+
+CREATE TABLE node_search
+(
+  name text NOT NULL,
+  field text NOT NULL,
+  value text,
+  CONSTRAINT node_search_pk PRIMARY KEY (name, field)
+)
+WITH (
+  OIDS=FALSE
+);
+ALTER TABLE node_search
+  OWNER TO goiardi;
+
+CREATE INDEX value_fulltext
+  ON node_search
+  USING gin
+  (to_tsvector('english'::regconfig, value));
+
+COMMIT;

--- a/sql-files/postgres-bundle/revert/node_search.sql
+++ b/sql-files/postgres-bundle/revert/node_search.sql
@@ -1,0 +1,7 @@
+-- Revert node_search
+
+BEGIN;
+
+DROP TABLE node_search;
+
+COMMIT;

--- a/sql-files/postgres-bundle/sqitch.plan
+++ b/sql-files/postgres-bundle/sqitch.plan
@@ -1,4 +1,4 @@
-%syntax-version=1.0.0-b2
+%syntax-version=1.0.0
 %project=goiardi_postgres
 %uri=http://ctdk.github.com/goiardi/postgres-support
 
@@ -43,3 +43,5 @@ shovey 2014-07-16T05:07:12Z Jeremy Bingham <jeremy@terqa.local> # add shovey tab
 node_latest_statuses [node_statuses] 2014-07-26T20:32:02Z Jeremy Bingham <jbingham@gmail.com> # Add a view to easily get nodes by their latest status
 shovey_insert_update [shovey] 2014-08-27T07:46:20Z Jeremy Bingham <jbingham@gmail.com> # insert/update functions for shovey
 @v0.8.0 2014-09-25T04:17:41Z Jeremy Bingham <jbingham@gmail.com> # Tag v0.8.0
+
+node_search 2015-02-02T13:33:41Z Zsolt <zsolt@takacs.cc># node_search create

--- a/sql-files/postgres-bundle/verify/node_search.sql
+++ b/sql-files/postgres-bundle/verify/node_search.sql
@@ -1,0 +1,7 @@
+-- Verify node_search
+
+BEGIN;
+
+SELECT name FROM node_search where value @@ 'asd:*'::tsquery;
+
+ROLLBACK;


### PR DESCRIPTION
I've implemented the basic field:value search for nodes using postgres. Range/Text searches are not implemented. Since postgres does not support foo\*bar type of wildcard searches they are converted to foo* and filtered afterwards. The filtering only uses the searched field, so it shouldn't be too slow.

This PR is based on the refactored search PR.