### PR TITLE
Fix client creation from cheffish

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -307,7 +307,7 @@ func (c *Client) UpdateFromJSON(jsonActor map[string]interface{}) util.Gerror {
 
 	/* Validations. */
 	/* Invalid top level elements */
-	validElements := []string{"name", "json_class", "chef_type", "validator", "org_name", "orgname", "public_key", "private_key", "admin", "certificate", "password", "node_name"}
+	validElements := []string{"name", "json_class", "chef_type", "validator", "org_name", "orgname", "public_key", "private_key", "admin", "certificate", "password", "node_name", "clientname"}
 ValidElem:
 	for k := range jsonActor {
 		for _, i := range validElements {


### PR DESCRIPTION
This isn't exactly a request because I'm not sure if this is the correct place yet. When creating a new Chef client with [Cheffish](https://github.com/chef/cheffish), an extra `clientname` key is added to the request and Goiardi throws an error.

Possible fixes I'm seeing:
1. Ignore the key in Goiardi (this PR)
2. Stop adding the key in [Chef](https://github.com/chef/chef/blob/master/lib/chef/chef_fs/data_handler/client_data_handler.rb#L11)
3. Remove the key in [Cheffish](https://github.com/chef/cheffish/blob/master/lib/cheffish/actor_provider_base.rb#L30)

Interested in your thoughts on the matter. Thanks!