### PR TITLE
add go runtime version to --version output

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,18 +25,20 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/BurntSushi/toml"
-	"github.com/ctdk/goas/v2/logger"
-	"github.com/jessevdk/go-flags"
 	"io/ioutil"
 	"log"
 	"net"
 	"os"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/ctdk/goas/v2/logger"
+	"github.com/jessevdk/go-flags"
 )
 
 // Conf is the master struct for holding configuration options.
@@ -201,7 +203,7 @@ func ParseConfigOptions() error {
 	}
 
 	if opts.Version {
-		fmt.Printf("goiardi version %s (aiming for compatibility with Chef Server version %s).\n", Version, ChefVersion)
+		fmt.Printf("goiardi version %s built with %s (aiming for compatibility with Chef Server version %s).\n", Version, runtime.Version(), ChefVersion)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
With the issues seen with `go1.5` and goiardi, it may make sense to include the go runtime version in the `--version` output.

Apologies for the import craziness, my editor runs goimports and it moves external deps to the bottom.