### PR TITLE
unescape query terms when searching FileIndex

### DIFF
--- a/indexer/file_index.go
+++ b/indexer/file_index.go
@@ -149,7 +149,7 @@ func (i *FileIndex) Search(idx string, term string, notop bool) (map[string]Docu
 	if term == "*:*" {
 		return idc.allDocs(), nil
 	}
-	results, err := idc.searchCollection(term, notop)
+	results, err := idc.searchCollection(unescape(term), notop)
 	return results, err
 }
 
@@ -767,4 +767,9 @@ func decompressText(buf []byte) (string, error) {
 		return "", err
 	}
 	return string(t), nil
+}
+
+func unescape(term string) string {
+	re := regexp.MustCompile(`\\(\S)`)
+	return re.ReplaceAllString(term, "$1")
 }

--- a/indexer/file_index_test.go
+++ b/indexer/file_index_test.go
@@ -1,0 +1,33 @@
+package indexer
+
+import "testing"
+
+func TestUnescapeSpecials(t *testing.T) {
+	specials := []string{
+		`+`, `-`, `&&`, `||`,
+		`!`, `(`, `)`, `{`, `}`,
+		`[`, `]`, `^`, `"`, `~`,
+		`*`, `?`, `:`, `\`,
+	}
+	for _, s := range specials {
+		in := `\` + s
+		if out := unescape(in); out != s {
+			t.Errorf("Unescaping %s failed. expected = %s, got = %s", in, s, out)
+		}
+	}
+}
+
+func TestUnescapedStrings(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{`00\:01\:02`, `00:01:02`},
+		{`foo \&& bar`, `foo && bar`},
+		{`some\\file\\path`, `some\file\path`},
+	}
+	for _, tt := range tests {
+		if out := unescape(tt.in); out != tt.out {
+			t.Errorf("Unescaping %s failed. expected = %s, got = %s", tt.in, tt.out, out)
+		}
+	}
+}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -19,6 +19,9 @@ package search
 import (
 	"encoding/gob"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/ctdk/goiardi/client"
 	"github.com/ctdk/goiardi/config"
 	"github.com/ctdk/goiardi/databag"
@@ -26,8 +29,6 @@ import (
 	"github.com/ctdk/goiardi/indexer"
 	"github.com/ctdk/goiardi/node"
 	"github.com/ctdk/goiardi/role"
-	"testing"
-	"time"
 )
 
 // Most search testing can be handled fine with chef-pedant, but that's no
@@ -88,6 +89,7 @@ func makeSearchItems() int {
 		dbi := make(map[string]interface{})
 		dbi["id"] = fmt.Sprintf("dbi%d", i)
 		dbi["foo"] = fmt.Sprintf("dbag_item_%d", i)
+		dbi["mac"] = fmt.Sprintf("01:02:03:04:05:%02d", i)
 		dbags[i].NewDBItem(dbi)
 		reindexObjs = append(reindexObjs, nodes[i])
 		reindexObjs = append(reindexObjs, roles[i])
@@ -244,6 +246,13 @@ func TestSearchDbag(t *testing.T) {
 
 func TestSearchDbagAll(t *testing.T) {
 	d, _ := searcher.Search("databag1", "*:*", 1000, "id ASC", 0, nil)
+	if len(d) != 1 {
+		t.Errorf("Incorrect number of items returned, expected 1, got %d", len(d))
+	}
+}
+
+func TestSearchBasicQueryEscaped(t *testing.T) {
+	d, _ := searcher.Search("databag1", "mac:01\\:02\\:03\\:04\\:05\\:01", 1000, "id ASC", 0, nil)
 	if len(d) != 1 {
 		t.Errorf("Incorrect number of items returned, expected 1, got %d", len(d))
 	}


### PR DESCRIPTION
This patch fixes a little buglet I just stumbled across. Query terms containing escaped special characters are searched on literally without any unescaping.

This patch unescapes query terms prior to search.