### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/gerror/error.go
+++ b/gerror/error.go
@@ -73,7 +73,7 @@ func (e *gerror) SetStatus(s int) {
 	e.status = s
 }
 
-// Returns the Error's HTTP status code.
+// Status returns the Error's HTTP status code.
 func (e *gerror) Status() int {
 	return e.status
 }

--- a/shovey/shovey.go
+++ b/shovey/shovey.go
@@ -134,7 +134,7 @@ func (e *qerror) SetStatus(s string) {
 	e.status = s
 }
 
-// Returns the Qerror's HTTP status code.
+// Status returns the Qerror's HTTP status code.
 func (e *qerror) Status() string {
 	return e.status
 }


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._