### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/gerror/error.go
+++ b/gerror/error.go
@@ -73,7 +73,7 @@ func (e *gerror) SetStatus(s int) {
 	e.status = s
 }
 
-// Returns the Error's HTTP status code.
+// Status returns the Error's HTTP status code.
 func (e *gerror) Status() int {
 	return e.status
 }

--- a/shovey/shovey.go
+++ b/shovey/shovey.go
@@ -134,7 +134,7 @@ func (e *qerror) SetStatus(s string) {
 	e.status = s
 }
 
-// Returns the Qerror's HTTP status code.
+// Status returns the Qerror's HTTP status code.
 func (e *qerror) Status() string {
 	return e.status
 }


### PR DESCRIPTION
Fix function comments following [Effective Go Guidelines](https://golang.org/doc/effective_go.html#commentary)