### PR TITLE
feat: sandbox id generation was producing useless cycles.

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -85,7 +85,9 @@ func New(checksumHash map[string]interface{}) (*Sandbox, error) {
 		if s, _ := Get(sandboxID); s != nil {
 			logger.Infof("Collision! Somehow %s already existed as a sandbox id on attempt %d. Trying again.", sandboxID, i)
 			sandboxID = ""
+			continue
 		}
+		break
 	}
 
 	if sandboxID == "" {


### PR DESCRIPTION
* **What, if anything, does this fix?** (If there's an existing issue, link it here.)
Sandbox id generation was using all 5 cycles even if it found a good id on the first run

* **What is the new behavior (if this is a feature change)?**
break the loop earlier in case we got what we need. 



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
