### PR TITLE
chore: s3 should be initialized only on --use-s3 flag, check for erro…

### DIFF
--- a/goiardi.go
+++ b/goiardi.go
@@ -134,7 +134,12 @@ func main() {
 		logger.Fatalf(merr.Error())
 		os.Exit(1)
 	}
-	util.InitS3(config.Config)
+	if config.Config.UseS3Upload {
+		err := util.InitS3(config.Config)
+		if err != nil {
+			logger.Criticalf("cannot init s3")
+		}
+	}
 	initGeneralStatsd(metricsBackend)
 	report.InitializeMetrics(metricsBackend)
 	search.InitializeMetrics(metricsBackend)

--- a/util/s3.go
+++ b/util/s3.go
@@ -41,7 +41,10 @@ var s3cli *s3client
 
 // InitS3 sets up the session and whatnot for using goiardi with S3.
 func InitS3(conf *config.Conf) error {
-	sess := session.New(&aws.Config{Region: aws.String(conf.AWSRegion), DisableSSL: aws.Bool(conf.AWSDisableSSL), Endpoint: aws.String(conf.S3Endpoint), S3ForcePathStyle: aws.Bool(false)})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String(conf.AWSRegion), DisableSSL: aws.Bool(conf.AWSDisableSSL), Endpoint: aws.String(conf.S3Endpoint), S3ForcePathStyle: aws.Bool(false)})
+	if err != nil {
+		return err
+	}
 
 	s3cli = new(s3client)
 	s3cli.bucket = conf.S3Bucket


### PR DESCRIPTION
* **What, if anything, does this fix?** (If there's an existing issue, link it here.)
Session.new is deprecated on aws sdk
added error check for session init
s3 should be initialized only if s3 is enabled

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
