### PR TITLE
feat: create a bootstrap command to initialize users on the first run.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type Conf struct {
 	SkipLogExtended      bool         `toml:"skip-log-extended"`
 	DoExport             bool
 	DoImport             bool
+	DoBootstrap          bool
 	ImpExFile            string
 	ObjMaxSize           int64    `toml:"obj-max-size"`
 	JSONReqMaxSize       int64    `toml:"json-req-max-size"`
@@ -192,6 +193,7 @@ type Options struct {
 	SkipLogExtended      bool         `long:"skip-log-extended" description:"If set, do not save a JSON encoded blob of the object being logged when logging an event." env:"GOIARDI_SKIP_LOG_EXTENDED"`
 	Export               string       `short:"x" long:"export" description:"Export all server data to the given file, exiting afterwards. Should be used with caution. Cannot be used at the same time as -m/--import."`
 	Import               string       `short:"m" long:"import" description:"Import data from the given file, exiting afterwards. Cannot be used at the same time as -x/--export."`
+	Bootstrap            bool         `long:"bootstrap" description:"Bootstrap the server creating default actors, their pem certificates. Exits afterwards"`
 	ObjMaxSize           int64        `short:"Q" long:"obj-max-size" description:"Maximum object size in bytes for the file store. Default 10485760 bytes (10MB)." env:"GOIARDI_OBJ_MAX_SIZE"`
 	JSONReqMaxSize       int64        `short:"j" long:"json-req-max-size" description:"Maximum size for a JSON request from the client. Per chef-pedant, default is 1000000." env:"GOIARDI_JSON_REQ_MAX_SIZE"`
 	UseUnsafeMemStore    bool         `long:"use-unsafe-mem-store" description:"Use the faster, but less safe, old method of storing data in the in-memory data store with pointers, rather than encoding the data with gob and giving a new copy of the object to each requestor. If this is enabled goiardi will run faster in in-memory mode, but one goroutine could change an object while it's being used by another. Has no effect when using an SQL backend. (DEPRECATED - will be removed in a future release.)"`
@@ -307,6 +309,8 @@ func ParseConfigOptions() error {
 		Config.ConfFile = opts.ConfFile
 		Config.FreezeData = false
 	}
+
+	Config.DoBootstrap = opts.Bootstrap
 
 	if opts.Export != "" && opts.Import != "" {
 		log.Println("Cannot use -x/--export and -m/--import flags together.")

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ To install goiardi from source:
 
     goiardi <options>
 
-   Or, you can look at the goiardi releases page on github at https://github.com/ctdk/goiardi/releases and see if there are precompiled binaries available for your platform, or check out the packages at https://packagecloud.io/ct/goiardi and see if there's one for your platform there. 
+   Or, you can look at the goiardi releases page on github at https://github.com/ctdk/goiardi/releases and see if there are precompiled binaries available for your platform, or check out the packages at https://packagecloud.io/ct/goiardi and see if there's one for your platform there.
 
 Another option is running goiardi in Docker. There's a Dockerfile in the root of the goiardi git repository that's suitable for running the local version of goiardi, but a goiardi repository on Docker Hub at https://hub.docker.com/r/ctdk/goiardi/ is also under development (the source repository for those docker images is at https://github.com/ctdk/goiardi-docker). Running goiardi under docker has always worked fine, but now that configuration options can be set with environment variables it's certainly easier to do so than before.
 
@@ -128,6 +128,8 @@ Currently available command line and config file options::
     -m, --import=               Import data from the given file, exiting
                                 afterwards. Cannot be used at the same time as
                                 -x/--export.
+        --bootstrap             Initialize server clients and admin user.
+                                Exits with status code 0 if everything went ok.
     -Q, --obj-max-size=         Maximum object size in bytes for the file store.
                                 Default 10485760 bytes (10MB).
                                 [$GOIARDI_OBJ_MAX_SIZE]

--- a/goiardi.go
+++ b/goiardi.go
@@ -203,6 +203,16 @@ func main() {
 		startNodeMonitor()
 	}
 
+	/* Create default clients and users. Currently chef-validator,
+	 * chef-webui, and admin. */
+	createDefaultActors()
+
+	//if we are in a bootstrap mode, then we've done everything we needed and can exit now
+	if config.Config.DoBootstrap {
+		logger.Infof("Bootstrap completed")
+		os.Exit(0)
+	}
+
 	if config.Config.PurgeNodeStatusAfter != "" {
 		startNodeStatusPurge()
 	}
@@ -215,9 +225,6 @@ func main() {
 		startSandboxPurge()
 	}
 
-	/* Create default clients and users. Currently chef-validator,
-	 * chef-webui, and admin. */
-	createDefaultActors()
 	handleSignals()
 
 	/* Register the various handlers, found in their own source files. */


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Ability to bootstrap goiardi installation

* **What is the new behavior (if this is a feature change)?**
Added new flag `--bootstrap`. When used it will introduce a clean exit from the app once core actors have been correctly created. Useful in situation of multi stage initial setup where you want to extract admin pem file and/or add a custom logic before actual goairdi deployment.

* **Does this PR introduce a breaking change?** no

