### PR TITLE
feat: improve error handling on cookbook.get

### DIFF
--- a/cookbook/versioning.go
+++ b/cookbook/versioning.go
@@ -18,11 +18,14 @@ package cookbook
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/tideland/golib/logger"
+
 	"github.com/ctdk/goiardi/depgraph"
 	"github.com/ctdk/goiardi/util"
 	gversion "github.com/hashicorp/go-version"
-	"strconv"
-	"strings"
 )
 
 // Types, functions, and methods for dealing with cookbook versioning that
@@ -61,7 +64,10 @@ func (v versionConstraint) Satisfied(head, tail *depgraph.Noun) (bool, error) {
 	if tMeta.version == "" {
 		verr.ViolationType = CookbookNoVersion
 		// but what constraint isn't met?
-		cb, _ := Get(tail.Name)
+		cb, _, err := Get(tail.Name)
+		if err != nil {
+			logger.Errorf("error while getting cookbook %s", tail.Name)
+		}
 		if cb != nil {
 			badver := cb.badConstraints(v)
 			verr.Constraint = strings.Join(badver, ",")

--- a/environments.go
+++ b/environments.go
@@ -397,9 +397,14 @@ func environmentHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			envResponse["run_list"] = runList
 		} else if op == "cookbooks" {
-			cb, err := cookbook.Get(opName)
-			if err != nil {
-				jsonErrorReport(w, r, err.Error(), http.StatusNotFound)
+			cb, found, err := cookbook.Get(opName)
+			switch {
+			case !found:
+				jsonErrorReport(w, r, fmt.Sprintf("Cannot find a cookbook named %s", opName), http.StatusNotFound)
+				return
+			case err != nil:
+				logger.Errorf(err.Error())
+				jsonErrorReport(w, r, fmt.Sprintf("Cannot get a cookbook named %s", opName), err.Status())
 				return
 			}
 			/* Here and, I think, here only, if num_versions isn't


### PR DESCRIPTION
* **What, if anything, does this fix?** 
In cookbook related code we have a very poor management of errors vs not found state. I suppose it because the support for db was added later on, and any errors coming from db (auth, db, etc) were not accounted for. If there was an error it was always assumed that it's due to cookbook non existing. 

This introduce a bit more granular handling of the issue and proper response codes (notfound vs internal error) are added. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Should not be the case. 


* **Other information**:
Some todos were added because underlying methods didn't support propagation of errors, those should be resolved at some point in the future as well. 
