### PR TITLE
fix: div by 0 computing gcPerSec runtime metric

### DIFF
--- a/goiardi.go
+++ b/goiardi.go
@@ -937,8 +937,9 @@ func initGeneralStatsd(metricsBackend met.Backend) {
 			pausePerTick.Value(int64(p))
 
 			countGC := int64(memStats.NumGC - lastGC)
-			diffTime := int64(now.Sub(lastSampleTime).Seconds())
-			gcPerSec.Value(countGC / diffTime)
+			if diffTime := int64(now.Sub(lastSampleTime).Seconds()); diffTime != 0 {
+				gcPerSec.Value(countGC / diffTime)
+			}
 			gcPerTick.Value(countGC)
 
 			if countGC > 0 {


### PR DESCRIPTION
* **What, if anything, does this fix?** (If there's an existing issue, link it here.)
At some scenarios it's possible for goiardi to crash with division/0 error message. 


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO

