### PR TITLE
Update Chef copyright to 2026 and Progress Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ License. See the LICENSE file for details.
 The goiardi documentation in the `docs` directory is licensed under a Creative
 Commons Attribution 4.0 International (CC-BY 4.0) License.
 
-Chef is copyright (c) 2008-2020 Chef Software (formerly Opscode, Inc.) and its
-various contributors.
+Chef is copyright (c) 2008-2026 Progress Software (formerly Chef Software and
+Opscode, Inc.) and its various contributors.
 
 The `depgraph` and `digraph` packages are vendored from Hashicorp's terraform
 package, and is under the Mozilla Public License version 2.0. The MPL is


### PR DESCRIPTION
## Summary

Updates the README copyright notice for Chef to reflect the current owner and year. Chef Software was acquired by Progress Software, so the notice now reads "Progress Software (formerly Chef Software and Opscode, Inc.)" and the year range is extended to 2026.

## Changes

- `README.md`: `Chef is copyright (c) 2008-2020 Chef Software (formerly Opscode, Inc.)` → `Chef is copyright (c) 2008-2026 Progress Software (formerly Chef Software and Opscode, Inc.)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)