### PR TITLE
Modernize Go idioms via gopls modernize analyzer

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -33,13 +33,13 @@ import (
 type Actor interface {
 	IsAdmin() bool
 	IsValidator() bool
-	IsSelf(interface{}) bool
+	IsSelf(any) bool
 	IsUser() bool
 	IsClient() bool
 	PublicKey() string
-	SetPublicKey(interface{}) error
+	SetPublicKey(any) error
 	GetName() string
-	CheckPermEdit(map[string]interface{}, string) util.Gerror
+	CheckPermEdit(map[string]any, string) util.Gerror
 }
 
 // GetReqUser gets the actor making the request. If use-auth is not on, always

--- a/authenticate_users.go
+++ b/authenticate_users.go
@@ -39,7 +39,7 @@ func authenticateUserHandler(w http.ResponseWriter, r *http.Request) {
 
 	dec := json.NewDecoder(r.Body)
 	dec.UseNumber()
-	authJSON := make(map[string]interface{})
+	authJSON := make(map[string]any)
 	if err := dec.Decode(&authJSON); err != nil {
 		jsonErrorReport(w, r, err.Error(), http.StatusBadRequest)
 		return
@@ -81,7 +81,7 @@ func validateLogin(auth *authenticator) authResponse {
 	return resp
 }
 
-func validateJSON(authJSON map[string]interface{}) (*authenticator, error) {
+func validateJSON(authJSON map[string]any) (*authenticator, error) {
 	auth := new(authenticator)
 	if name, ok := authJSON["name"]; ok {
 		switch name := name.(type) {

--- a/authentication/go-chef/chef/http.go
+++ b/authentication/go-chef/chef/http.go
@@ -28,7 +28,8 @@ type Body struct {
 }
 
 // AuthConfig representing a client and a private key used for encryption
-//  This is embedded in the Client type
+//
+//	This is embedded in the Client type
 type AuthConfig struct {
 	PrivateKey *rsa.PrivateKey
 	ClientName string
@@ -143,7 +144,7 @@ func NewClient(cfg *Config) (*Client, error) {
 }
 
 // magicRequestDecoder performs a request on an endpoint, and decodes the response into the passed in Type
-func (c *Client) magicRequestDecoder(method, path string, body io.Reader, v interface{}) error {
+func (c *Client) magicRequestDecoder(method, path string, body io.Reader, v any) error {
 	req, err := c.NewRequest(method, path, body)
 	if err != nil {
 		return err
@@ -209,7 +210,7 @@ func CheckResponse(r *http.Response) error {
 }
 
 // Do is used either internally via our magic request shite or a user may use it
-func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
+func (c *Client) Do(req *http.Request, v any) (*http.Response, error) {
 	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -300,4 +301,4 @@ func PrivateKeyFromString(key []byte) (*rsa.PrivateKey, error) {
 	return rsaKey, nil
 }
 
-func debug(fmt string, args ...interface{}) {}
+func debug(fmt string, args ...any) {}

--- a/chefcrypto/chefcrypto.go
+++ b/chefcrypto/chefcrypto.go
@@ -71,7 +71,7 @@ func GenerateRSAKeys() (string, string, error) {
 }
 
 // ValidatePublicKey checks that the provided public key is valid.
-func ValidatePublicKey(publicKey interface{}) (bool, error) {
+func ValidatePublicKey(publicKey any) (bool, error) {
 	switch publicKey := publicKey.(type) {
 	case string:
 		// at the moment we don't care about the pub interface

--- a/chefcrypto/chefcrypto_test.go
+++ b/chefcrypto/chefcrypto_test.go
@@ -56,7 +56,7 @@ var oldLabelPubKey = "-----BEGIN RSA PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAA
 var onePubKey = "1"
 var realBadPubKey = "-----BEGIN PUBLIC KEY-----\nI'm bad to the bone\n-----END PUBLIC KEY-----"
 var arrPubKey = []string{}
-var mapPubKey = make(map[string]interface{})
+var mapPubKey = make(map[string]any)
 
 func TestGoodPubKey(t *testing.T) {
 	ok, err := ValidatePublicKey(goodPubKey)

--- a/client/client.go
+++ b/client/client.go
@@ -250,8 +250,8 @@ func (c *Client) Delete() error {
 
 // ToJSON converts the client object into a JSON object, massaging it as needed
 // to make chef-pedant happy.
-func (c *Client) ToJSON() map[string]interface{} {
-	toJSON := make(map[string]interface{})
+func (c *Client) ToJSON() map[string]any {
+	toJSON := make(map[string]any)
 	toJSON["name"] = c.Name
 	toJSON["admin"] = c.Admin
 	toJSON["public_key"] = c.PublicKey()
@@ -338,7 +338,7 @@ func (c *Client) Rename(newName string) util.Gerror {
 }
 
 // NewFromJSON builds a new client/user from a json object.
-func NewFromJSON(jsonActor map[string]interface{}) (*Client, util.Gerror) {
+func NewFromJSON(jsonActor map[string]any) (*Client, util.Gerror) {
 	actorName, nerr := util.ValidateAsString(jsonActor["name"])
 	if nerr != nil {
 		return nil, nerr
@@ -356,7 +356,7 @@ func NewFromJSON(jsonActor map[string]interface{}) (*Client, util.Gerror) {
 
 // UpdateFromJSON updates a client/user from a json object. Does a bunch of
 // validations inside rather than in the handler.
-func (c *Client) UpdateFromJSON(jsonActor map[string]interface{}) util.Gerror {
+func (c *Client) UpdateFromJSON(jsonActor map[string]any) util.Gerror {
 	actorName, nerr := util.ValidateAsString(jsonActor["name"])
 	if nerr != nil {
 		return nerr
@@ -445,7 +445,7 @@ ValidElem:
 
 // ValidatePublicKey checks that the provided public key is valid. Wrapper around
 // chefcrypto.ValidatePublicKey(), but with a different error type.
-func ValidatePublicKey(publicKey interface{}) (bool, util.Gerror) {
+func ValidatePublicKey(publicKey any) (bool, util.Gerror) {
 	ok, pkerr := chefcrypto.ValidatePublicKey(publicKey)
 	var err util.Gerror
 	if !ok {
@@ -510,7 +510,7 @@ func (c *Client) Index() string {
 }
 
 // Flatten out the client so it's suitable for indexing.
-func (c *Client) Flatten() map[string]interface{} {
+func (c *Client) Flatten() map[string]any {
 	return util.FlattenObj(c.flatExport())
 }
 
@@ -539,7 +539,7 @@ func (c *Client) IsValidator() bool {
 }
 
 // IsSelf returns true if the other actor provided is the same as the caller.
-func (c *Client) IsSelf(other interface{}) bool {
+func (c *Client) IsSelf(other any) bool {
 	if !useAuth() {
 		return true
 	}
@@ -577,7 +577,7 @@ func (c *Client) PublicKey() string {
 }
 
 // SetPublicKey sets the client's public key.
-func (c *Client) SetPublicKey(pk interface{}) error {
+func (c *Client) SetPublicKey(pk any) error {
 	switch pk := pk.(type) {
 	case string:
 		ok, err := ValidatePublicKey(pk)
@@ -598,7 +598,7 @@ func (c *Client) SetPublicKey(pk interface{}) error {
 
 // CheckPermEdit checks to see if the client is trying to edit admin and
 // validator attributes, and if it has permissions to do so.
-func (c *Client) CheckPermEdit(clientData map[string]interface{}, perm string) util.Gerror {
+func (c *Client) CheckPermEdit(clientData map[string]any, perm string) util.Gerror {
 	gerr := util.Errorf("You are not allowed to take this action.")
 	gerr.SetStatus(http.StatusForbidden)
 
@@ -665,9 +665,9 @@ func AllClients() []*Client {
 }
 
 // ExportAllClients returns all clients in a fashion suitable for exporting.
-func ExportAllClients() []interface{} {
+func ExportAllClients() []any {
 	clients := AllClients()
-	export := make([]interface{}, len(clients))
+	export := make([]any, len(clients))
 	for i, c := range clients {
 		export[i] = c.export()
 	}

--- a/client/sql_funcs.go
+++ b/client/sql_funcs.go
@@ -87,7 +87,7 @@ func getMultiSQL(clientNames []string) ([]*Client, error) {
 		return nil, err
 	}
 	defer stmt.Close()
-	nameArgs := make([]interface{}, len(clientNames))
+	nameArgs := make([]any, len(clientNames))
 	for i, v := range clientNames {
 		nameArgs[i] = v
 	}

--- a/common.go
+++ b/common.go
@@ -28,8 +28,8 @@ import (
 	"github.com/tideland/golib/logger"
 )
 
-func parseObjJSON(data io.ReadCloser) (map[string]interface{}, error) {
-	objData := make(map[string]interface{})
+func parseObjJSON(data io.ReadCloser) (map[string]any, error) {
+	objData := make(map[string]any)
 	dec := json.NewDecoder(data)
 	dec.UseNumber()
 
@@ -39,7 +39,7 @@ func parseObjJSON(data io.ReadCloser) (map[string]interface{}, error) {
 	return checkAttrs(objData)
 }
 
-func checkAttrs(objData map[string]interface{}) (map[string]interface{}, error) {
+func checkAttrs(objData map[string]any) (map[string]any, error) {
 	/* If this kind of object comes with a run_list, process it */
 	if _, ok := objData["run_list"]; ok {
 		rl, err := chkRunList(objData["run_list"])
@@ -52,7 +52,7 @@ func checkAttrs(objData map[string]interface{}) (map[string]interface{}, error) 
 	/* And if we have env_run_lists */
 	if _, ok := objData["env_run_lists"]; ok {
 		switch erl := objData["env_run_lists"].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			newEnvRunList := make(map[string][]string, len(erl))
 			var erlerr error
 			for i, v := range erl {
@@ -74,7 +74,7 @@ func checkAttrs(objData map[string]interface{}) (map[string]interface{}, error) 
 		/* Don't add if it doesn't exist in the json data at all */
 		if _, ok := objData[k]; ok {
 			if objData[k] == nil {
-				objData[k] = make(map[string]interface{})
+				objData[k] = make(map[string]any)
 			}
 		}
 	}
@@ -110,9 +110,9 @@ func checkAccept(w http.ResponseWriter, r *http.Request, acceptType string) erro
 	return err
 }
 
-func chkRunList(rl interface{}) ([]string, error) {
+func chkRunList(rl any) ([]string, error) {
 	switch o := rl.(type) {
-	case []interface{}:
+	case []any:
 		_ = o
 		newRunList := make([]string, len(o))
 		for i, v := range o {

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -951,10 +952,5 @@ func UsingExternalSecrets() bool {
 }
 
 func PprofWhitelisted(remoteIP net.IP) bool {
-	for _, wl := range pprofWhitelist {
-		if remoteIP.Equal(wl) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(pprofWhitelist, remoteIP.Equal)
 }

--- a/cookbook/cookbook.go
+++ b/cookbook/cookbook.go
@@ -56,22 +56,22 @@ type Cookbook struct {
 // CookbookVersion is the meat of the cookbook. This is what's set when a new
 // cookbook is uploaded.
 type CookbookVersion struct {
-	CookbookName string                   `json:"cookbook_name"`
-	Name         string                   `json:"name"`
-	Version      string                   `json:"version"`
-	ChefType     string                   `json:"chef_type"`
-	JSONClass    string                   `json:"json_class"`
-	Definitions  []map[string]interface{} `json:"definitions"`
-	Libraries    []map[string]interface{} `json:"libraries"`
-	Attributes   []map[string]interface{} `json:"attributes"`
-	Recipes      []map[string]interface{} `json:"recipes"`
-	Providers    []map[string]interface{} `json:"providers"`
-	Resources    []map[string]interface{} `json:"resources"`
-	Templates    []map[string]interface{} `json:"templates"`
-	RootFiles    []map[string]interface{} `json:"root_files"`
-	Files        []map[string]interface{} `json:"files"`
-	IsFrozen     bool                     `json:"frozen?"`
-	Metadata     map[string]interface{}   `json:"metadata"`
+	CookbookName string           `json:"cookbook_name"`
+	Name         string           `json:"name"`
+	Version      string           `json:"version"`
+	ChefType     string           `json:"chef_type"`
+	JSONClass    string           `json:"json_class"`
+	Definitions  []map[string]any `json:"definitions"`
+	Libraries    []map[string]any `json:"libraries"`
+	Attributes   []map[string]any `json:"attributes"`
+	Recipes      []map[string]any `json:"recipes"`
+	Providers    []map[string]any `json:"providers"`
+	Resources    []map[string]any `json:"resources"`
+	Templates    []map[string]any `json:"templates"`
+	RootFiles    []map[string]any `json:"root_files"`
+	Files        []map[string]any `json:"files"`
+	IsFrozen     bool             `json:"frozen?"`
+	Metadata     map[string]any   `json:"metadata"`
 	id           int32
 	cookbookID   int32
 }
@@ -187,7 +187,7 @@ func Get(name string) (cookbook *Cookbook, found bool, gerror util.Gerror) {
 
 	//get the cookbook from internal datastore
 	ds := datastore.New()
-	var c interface{}
+	var c any
 	c, found = ds.Get("cookbook", name)
 	if !found {
 		return nil, false, nil
@@ -317,11 +317,11 @@ func (c *Cookbook) LatestVersion() *CookbookVersion {
 
 // CookbookLister lists all of the cookbooks on the server, along with some
 // information like URL, available versions, etc.
-func CookbookLister(numResults interface{}) map[string]interface{} {
+func CookbookLister(numResults any) map[string]any {
 	if config.UsingDB() {
 		return cookbookListerSQL(numResults)
 	}
-	cr := make(map[string]interface{})
+	cr := make(map[string]any)
 	for _, cb := range AllCookbooks() {
 		cr[cb.Name] = cb.InfoHash(numResults)
 	}
@@ -330,13 +330,13 @@ func CookbookLister(numResults interface{}) map[string]interface{} {
 
 // CookbookLatest returns the URL of the latest version of each cookbook on the
 // server.
-func CookbookLatest() map[string]interface{} {
-	latest := make(map[string]interface{})
+func CookbookLatest() map[string]any {
+	latest := make(map[string]any)
 	if config.UsingDB() {
 		cs := CookbookLister("")
 		for name, cbdata := range cs {
-			if len(cbdata.(map[string]interface{})["versions"].([]interface{})) > 0 {
-				latest[name] = cbdata.(map[string]interface{})["versions"].([]interface{})[0].(map[string]string)["url"]
+			if len(cbdata.(map[string]any)["versions"].([]any)) > 0 {
+				latest[name] = cbdata.(map[string]any)["versions"].([]any)[0].(map[string]string)["url"]
 			}
 		}
 	} else {
@@ -370,20 +370,20 @@ func CookbookRecipes() ([]string, util.Gerror) {
 
 // InfoHash gets numResults (or all if numResults is nil) versions of a
 // cookbook,returning a hash describing the cookbook and the versions returned.
-func (c *Cookbook) InfoHash(numResults interface{}) map[string]interface{} {
+func (c *Cookbook) InfoHash(numResults any) map[string]any {
 	return c.infoHashBase(numResults, "")
 }
 
 // ConstrainedInfoHash gets numResults (or all if numResults is nil) versions of
 // a cookbook that match the given constraint and returns a hash describing the
 // cookbook and the versions returned.
-func (c *Cookbook) ConstrainedInfoHash(numResults interface{}, constraint string) map[string]interface{} {
+func (c *Cookbook) ConstrainedInfoHash(numResults any, constraint string) map[string]any {
 	return c.infoHashBase(numResults, constraint)
 }
 
 // DependsCookbooks will, for the given run list and environment constraints,
 // return the cookbook dependencies.
-func DependsCookbooks(runList []string, envConstraints map[string]string) (map[string]interface{}, error) {
+func DependsCookbooks(runList []string, envConstraints map[string]string) (map[string]any, error) {
 	nodes := make(map[string]*depgraph.Noun)
 	runListRef := make([]string, len(runList))
 
@@ -455,7 +455,7 @@ func DependsCookbooks(runList []string, envConstraints map[string]string) (map[s
 		return nil, err
 	}
 
-	cookbookDeps := make(map[string]interface{}, len(cbShelf))
+	cookbookDeps := make(map[string]any, len(cbShelf))
 	for k, c := range cbShelf {
 		constraints := nodes[k].Meta.(*depMeta).constraint
 		cbv := c.latestMultiConstraint(constraints)
@@ -467,7 +467,7 @@ func DependsCookbooks(runList []string, envConstraints map[string]string) (map[s
 
 		for _, cd := range chkDiv {
 			if gcbvJSON[cd] == nil {
-				gcbvJSON[cd] = make([]map[string]interface{}, 0)
+				gcbvJSON[cd] = make([]map[string]any, 0)
 			}
 		}
 		cookbookDeps[cbv.CookbookName] = gcbvJSON
@@ -515,7 +515,7 @@ func (c *Cookbook) badConstraints(constraints versionConstraint) []string {
 }
 
 func (cbv *CookbookVersion) getDependencies(g *depgraph.Graph, nodes map[string]*depgraph.Noun, cbShelf map[string]*Cookbook) {
-	depList := cbv.Metadata["dependencies"].(map[string]interface{})
+	depList := cbv.Metadata["dependencies"].(map[string]any)
 	for r, c2 := range depList {
 		if _, ok := nodes[r]; ok {
 			if nodes[r].Meta.(*depMeta).noVersion || nodes[r].Meta.(*depMeta).notFound {
@@ -585,8 +585,8 @@ func (cbv *CookbookVersion) getDependencies(g *depgraph.Graph, nodes map[string]
 	}
 }
 
-func (c *Cookbook) infoHashBase(numResults interface{}, constraint string) map[string]interface{} {
-	cbHash := make(map[string]interface{})
+func (c *Cookbook) infoHashBase(numResults any, constraint string) map[string]any {
+	cbHash := make(map[string]any)
 	cbHash["url"] = util.ObjURL(c)
 
 	nr := 0
@@ -606,7 +606,7 @@ func (c *Cookbook) infoHashBase(numResults interface{}, constraint string) map[s
 		allVersions = true
 	}
 
-	cbHash["versions"] = make([]interface{}, 0)
+	cbHash["versions"] = make([]any, 0)
 
 	var constraintVersion string
 	var constraintOp string
@@ -646,7 +646,7 @@ VerLoop:
 		cvInfo := make(map[string]string)
 		cvInfo["url"] = util.CustomObjURL(c, cv.Version)
 		cvInfo["version"] = cv.Version
-		cbHash["versions"] = append(cbHash["versions"].([]interface{}), cvInfo)
+		cbHash["versions"] = append(cbHash["versions"].([]any), cvInfo)
 		nr++
 	}
 	return cbHash
@@ -682,11 +682,11 @@ func (c *Cookbook) LatestConstrained(constraint string) *CookbookVersion {
 // Universe returns a hash of the cookbooks stored on this server, with a list
 // of each version of each cookbook formatted to be compatible with the
 // supermarket/berks /universe endpoint.
-func Universe() map[string]map[string]interface{} {
+func Universe() map[string]map[string]any {
 	if config.UsingDB() {
 		return universeSQL()
 	}
-	universe := make(map[string]map[string]interface{})
+	universe := make(map[string]map[string]any)
 
 	for _, cb := range AllCookbooks() {
 		universe[cb.Name] = cb.universeFormat()
@@ -696,10 +696,10 @@ func Universe() map[string]map[string]interface{} {
 
 // universeFormat returns a sorted list of this cookbook's versions, formatted
 // to be compatible with the supermarket/berks /universe endpoint.
-func (c *Cookbook) universeFormat() map[string]interface{} {
-	u := make(map[string]interface{})
+func (c *Cookbook) universeFormat() map[string]any {
+	u := make(map[string]any)
 	for _, cbv := range c.sortedVersions() {
-		v := make(map[string]interface{})
+		v := make(map[string]any)
 		v["location_path"] = util.CustomObjURL(c, cbv.Version)
 		v["location_type"] = "chef_server"
 		v["dependencies"] = cbv.Metadata["dependencies"]
@@ -711,7 +711,7 @@ func (c *Cookbook) universeFormat() map[string]interface{} {
 /* CookbookVersion methods and functions */
 
 // NewVersion creates a new version of the cookbook.
-func (c *Cookbook) NewVersion(cbVersion string, cbvData map[string]interface{}) (*CookbookVersion, util.Gerror) {
+func (c *Cookbook) NewVersion(cbVersion string, cbvData map[string]any) (*CookbookVersion, util.Gerror) {
 	if _, err := c.GetVersion(cbVersion); err == nil {
 		err := util.Errorf("Version %s of cookbook %s already exists, and shouldn't be created like this. Use UpdateVersion instead.", cbVersion, c.Name)
 		err.SetStatus(http.StatusConflict)
@@ -771,7 +771,7 @@ func (c *Cookbook) GetVersion(cbVersion string) (*CookbookVersion, util.Gerror) 
 		if cbv != nil {
 			datastore.ChkNilArray(cbv)
 			if cbv.Recipes == nil {
-				cbv.Recipes = make([]map[string]interface{}, 0)
+				cbv.Recipes = make([]map[string]any, 0)
 			}
 		}
 	}
@@ -874,7 +874,7 @@ func (c *Cookbook) DeleteVersion(cbVersion string) util.Gerror {
 }
 
 // UpdateVersion updates a specific version of a cookbook.
-func (cbv *CookbookVersion) UpdateVersion(cbvData map[string]interface{}, force bool) util.Gerror {
+func (cbv *CookbookVersion) UpdateVersion(cbvData map[string]any, force bool) util.Gerror {
 	/* Allow force to update a frozen cookbook */
 	if cbv.IsFrozen == true && !force {
 		err := util.Errorf("The cookbook %s at version %s is frozen. Use the 'force' option to override.", cbv.CookbookName, cbv.Version)
@@ -987,7 +987,7 @@ ValidElem:
 	cbv.Definitions = convertToCookbookDiv(cbvData["definitions"])
 	cbv.Libraries = convertToCookbookDiv(cbvData["libraries"])
 	cbv.Attributes = convertToCookbookDiv(cbvData["attributes"])
-	cbv.Recipes = cbvData["recipes"].([]map[string]interface{})
+	cbv.Recipes = cbvData["recipes"].([]map[string]any)
 	cbv.Providers = convertToCookbookDiv(cbvData["providers"])
 	cbv.Resources = convertToCookbookDiv(cbvData["resources"])
 	cbv.Templates = convertToCookbookDiv(cbvData["templates"])
@@ -996,7 +996,7 @@ ValidElem:
 	if cbv.IsFrozen != true {
 		cbv.IsFrozen = cbvData["frozen?"].(bool)
 	}
-	cbv.Metadata = cbvData["metadata"].(map[string]interface{})
+	cbv.Metadata = cbvData["metadata"].(map[string]any)
 
 	/* If we're using SQL, update this version in the DB. */
 	if config.UsingDB() {
@@ -1023,9 +1023,9 @@ ValidElem:
 	return nil
 }
 
-func convertToCookbookDiv(div interface{}) []map[string]interface{} {
+func convertToCookbookDiv(div any) []map[string]any {
 	switch div := div.(type) {
-	case []map[string]interface{}:
+	case []map[string]any:
 		return div
 	default:
 		return nil
@@ -1058,8 +1058,8 @@ func (cbv *CookbookVersion) fileHashes() []string {
 
 // ToJSON is a helper function that coverts the internal representation of a
 // cookbook version to JSON in a way that knife and chef-client expect.
-func (cbv *CookbookVersion) ToJSON(method string) map[string]interface{} {
-	toJSON := make(map[string]interface{})
+func (cbv *CookbookVersion) ToJSON(method string) map[string]any {
+	toJSON := make(map[string]any)
 	toJSON["name"] = cbv.Name
 	toJSON["cookbook_name"] = cbv.CookbookName
 	if cbv.Version != "0.0.0" {
@@ -1072,7 +1072,7 @@ func (cbv *CookbookVersion) ToJSON(method string) map[string]interface{} {
 	if cbv.Recipes != nil {
 		toJSON["recipes"] = methodize(method, cbv.Recipes)
 	} else {
-		toJSON["recipes"] = make([]map[string]interface{}, 0)
+		toJSON["recipes"] = make([]map[string]any, 0)
 	}
 	toJSON["metadata"] = cbv.Metadata
 
@@ -1107,12 +1107,12 @@ func (cbv *CookbookVersion) ToJSON(method string) map[string]interface{} {
 	return toJSON
 }
 
-func methodize(method string, cbThing []map[string]interface{}) []map[string]interface{} {
-	retHash := make([]map[string]interface{}, len(cbThing))
+func methodize(method string, cbThing []map[string]any) []map[string]any {
+	retHash := make([]map[string]any, len(cbThing))
 	baseURL := config.ServerBaseURL()
 	r := regexp.MustCompile(`/file_store/`)
 	for i, v := range cbThing {
-		retHash[i] = make(map[string]interface{})
+		retHash[i] = make(map[string]any)
 		chkSum := cbThing[i]["checksum"].(string)
 		for k, j := range v {
 			if method == "PUT" && k == "url" {
@@ -1138,7 +1138,7 @@ func methodize(method string, cbThing []map[string]interface{}) []map[string]int
 	return retHash
 }
 
-func getAttrHashes(attr []map[string]interface{}) []string {
+func getAttrHashes(attr []map[string]any) []string {
 	hashes := make([]string, len(attr))
 	for i, v := range attr {
 		/* Woo, type assertion again */

--- a/cookbook/cookbook_test.go
+++ b/cookbook/cookbook_test.go
@@ -44,7 +44,7 @@ func TestLatestConstrained(t *testing.T) {
 	gob.Register(c)
 	v := new(CookbookVersion)
 	gob.Register(v)
-	rm := make(map[string]interface{})
+	rm := make(map[string]any)
 	gob.Register(rm)
 
 	a := []string{"0ab75b43c726c3e7c00d7950dd6c3577", "b43166991a65cc7e711a018b93105544", "e2ff77580f69d7612e6a67640fdc2fe0", "5822b0e3808ed57308a0eff8b61f7dc2"}
@@ -88,7 +88,7 @@ func TestLatestConstrained(t *testing.T) {
 
 	for _, tc := range conTests {
 		tcb := cb.ConstrainedInfoHash("1", tc.constraint)
-		vs := tcb["versions"].([]interface{})
+		vs := tcb["versions"].([]any)
 		lvs := len(vs)
 
 		if lvs != tc.expectedNumResults {
@@ -104,7 +104,7 @@ func TestLatestConstrained(t *testing.T) {
 	}
 }
 
-func loadCookbookFromJSON(path string) (map[string]interface{}, error) {
+func loadCookbookFromJSON(path string) (map[string]any, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func loadCookbookFromJSON(path string) (map[string]interface{}, error) {
 	defer f.Close()
 
 	dec := json.NewDecoder(f)
-	var mc map[string]interface{}
+	var mc map[string]any
 	if err = dec.Decode(&mc); err != nil {
 		return nil, err
 	}

--- a/cookbook/deperr.go
+++ b/cookbook/deperr.go
@@ -54,8 +54,8 @@ func (d *DependsError) String() string {
 	return d.Error()
 }
 
-func (d *DependsError) ErrMap() map[string]interface{} {
-	errMap := make(map[string]interface{})
+func (d *DependsError) ErrMap() map[string]any {
+	errMap := make(map[string]any)
 
 	allMsgs := make([]string, 0)
 	notFound := make([]*versionConstraintError, 0)

--- a/cookbook/sql_funcs.go
+++ b/cookbook/sql_funcs.go
@@ -513,8 +513,8 @@ func (cbv *CookbookVersion) deleteCookbookVersionSQL() util.Gerror {
 	return nil
 }
 
-func universeSQL() map[string]map[string]interface{} {
-	universe := make(map[string]map[string]interface{})
+func universeSQL() map[string]map[string]any {
+	universe := make(map[string]map[string]any)
 	var (
 		major int64
 		minor int64
@@ -545,8 +545,8 @@ func universeSQL() map[string]map[string]interface{} {
 
 	for rows.Next() {
 		var metb sql.RawBytes
-		metadata := make(map[string]interface{})
-		u := make(map[string]interface{})
+		metadata := make(map[string]any)
+		u := make(map[string]any)
 		err := rows.Scan(&major, &minor, &patch, &name, &metb)
 		if err != nil {
 			log.Fatal(err)
@@ -566,7 +566,7 @@ func universeSQL() map[string]map[string]interface{} {
 			u["dependencies"] = metadata["dependencies"]
 		}
 		if _, ok := universe[name]; !ok {
-			universe[name] = make(map[string]interface{})
+			universe[name] = make(map[string]any)
 		}
 		universe[name][version] = u
 	}
@@ -577,11 +577,11 @@ func universeSQL() map[string]map[string]interface{} {
 	return universe
 }
 
-func cookbookListerSQL(numResults interface{}) map[string]interface{} {
+func cookbookListerSQL(numResults any) map[string]any {
 	var numVersions int
 	allVersions := false
 
-	cl := make(map[string]interface{})
+	cl := make(map[string]any)
 
 	if numResults != "" && numResults != "all" {
 		numVersions, _ = strconv.Atoi(numResults.(string))
@@ -627,9 +627,9 @@ func cookbookListerSQL(numResults interface{}) map[string]interface{} {
 	for name, versions := range scratch {
 		nr := 0
 		cburl := fmt.Sprintf("/cookbooks/%s", name)
-		cb := make(map[string]interface{})
+		cb := make(map[string]any)
 		cb["url"] = util.CustomURL(cburl)
-		cb["versions"] = make([]interface{}, 0)
+		cb["versions"] = make([]any, 0)
 		for _, ver := range versions {
 			if !allVersions && nr >= numVersions {
 				break
@@ -637,7 +637,7 @@ func cookbookListerSQL(numResults interface{}) map[string]interface{} {
 			cv := make(map[string]string)
 			cv["url"] = util.CustomURL(fmt.Sprintf("/cookbooks/%s/%s", name, ver))
 			cv["version"] = ver
-			cb["versions"] = append(cb["versions"].([]interface{}), cv)
+			cb["versions"] = append(cb["versions"].([]any), cv)
 			nr++
 		}
 		cl[name] = cb
@@ -672,7 +672,7 @@ func cookbookRecipesSQL() ([]string, util.Gerror) {
 	for rows.Next() {
 		var n, v string
 		var rec sql.RawBytes
-		recipes := make([]map[string]interface{}, 0)
+		recipes := make([]map[string]any, 0)
 		err := rows.Scan(&v, &n, &rec)
 		if seen[n] {
 			continue

--- a/cookbooks.go
+++ b/cookbooks.go
@@ -33,7 +33,7 @@ import (
 func cookbookHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	pathArray := splitPath(r.URL.Path)
-	cookbookResponse := make(map[string]interface{})
+	cookbookResponse := make(map[string]any)
 
 	opUser, oerr := reqctx.CtxReqUser(r.Context())
 	if oerr != nil {
@@ -253,7 +253,7 @@ func cookbookHandler(w http.ResponseWriter, r *http.Request) {
 					chkDiv := []string{"definitions", "libraries", "attributes", "providers", "resources", "templates", "root_files", "files"}
 					for _, cd := range chkDiv {
 						if cookbookResponse[cd] == nil {
-							cookbookResponse[cd] = make([]map[string]interface{}, 0)
+							cookbookResponse[cd] = make([]map[string]any, 0)
 						}
 					}
 				}

--- a/data.go
+++ b/data.go
@@ -34,7 +34,7 @@ func dataHandler(w http.ResponseWriter, r *http.Request) {
 
 	pathArray := splitPath(r.URL.Path)
 
-	dbResponse := make(map[string]interface{})
+	dbResponse := make(map[string]any)
 	opUser, oerr := reqctx.CtxReqUser(r.Context())
 	if oerr != nil {
 		jsonErrorReport(w, r, oerr.Error(), oerr.Status())

--- a/databag/databag.go
+++ b/databag/databag.go
@@ -44,11 +44,11 @@ type DataBag struct {
 
 // DataBagItem is an individual item within a data bag.
 type DataBagItem struct {
-	Name        string                 `json:"name"`
-	ChefType    string                 `json:"chef_type"`
-	JSONClass   string                 `json:"json_class"`
-	DataBagName string                 `json:"data_bag"`
-	RawData     map[string]interface{} `json:"raw_data"`
+	Name        string         `json:"name"`
+	ChefType    string         `json:"chef_type"`
+	JSONClass   string         `json:"json_class"`
+	DataBagName string         `json:"data_bag"`
+	RawData     map[string]any `json:"raw_data"`
 	id          int32
 	dataBagID   int32
 	origName    string
@@ -121,7 +121,7 @@ func Get(dbName string) (*DataBag, util.Gerror) {
 			dataBag = d.(*DataBag)
 			for _, v := range dataBag.DataBagItems {
 				z := datastore.WalkMapForNil(v.RawData)
-				v.RawData = z.(map[string]interface{})
+				v.RawData = z.(map[string]any)
 			}
 		}
 	}
@@ -213,7 +213,7 @@ func (dbi *DataBagItem) URLType() string {
 /* Data bag item functions and methods */
 
 // NewDBItem creates a new data bag item in the associated data bag.
-func (db *DataBag) NewDBItem(rawDbagItem map[string]interface{}) (*DataBagItem, util.Gerror) {
+func (db *DataBag) NewDBItem(rawDbagItem map[string]any) (*DataBagItem, util.Gerror) {
 	var dbiID string
 	var dbagItem *DataBagItem
 	switch t := rawDbagItem["id"].(type) {
@@ -280,7 +280,7 @@ func (db *DataBag) NewDBItem(rawDbagItem map[string]interface{}) (*DataBagItem, 
 }
 
 // UpdateDBItem updates a data bag item in this data bag.
-func (db *DataBag) UpdateDBItem(dbiID string, rawDbagItem map[string]interface{}) (*DataBagItem, error) {
+func (db *DataBag) UpdateDBItem(dbiID string, rawDbagItem map[string]any) (*DataBagItem, error) {
 	dbItem, err := db.GetDBItem(dbiID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -416,13 +416,13 @@ func (db *DataBag) fullDBItemName(dbItemName string) string {
 
 // RawDataBagJSON extract the data bag item's raw data from the request, saving
 // it to the server.
-func RawDataBagJSON(data io.ReadCloser) map[string]interface{} {
-	rawDbagItem := make(map[string]interface{})
+func RawDataBagJSON(data io.ReadCloser) map[string]any {
+	rawDbagItem := make(map[string]any)
 	dec := json.NewDecoder(data)
 	dec.UseNumber()
 
 	dec.Decode(&rawDbagItem)
-	var rawData map[string]interface{}
+	var rawData map[string]any
 
 	/* The way data can come from knife may
 	 * not be entirely consistent. Use
@@ -432,7 +432,7 @@ func RawDataBagJSON(data io.ReadCloser) map[string]interface{} {
 	 * stuff added. */
 
 	if _, ok := rawDbagItem["raw_data"]; ok {
-		rawData = rawDbagItem["raw_data"].(map[string]interface{})
+		rawData = rawDbagItem["raw_data"].(map[string]any)
 	} else {
 		rawData = rawDbagItem
 	}
@@ -473,8 +473,8 @@ func (dbi *DataBagItem) Index() string {
 }
 
 // Flatten a data bag item out so it's suitable for indexing.
-func (dbi *DataBagItem) Flatten() map[string]interface{} {
-	flatten := make(map[string]interface{})
+func (dbi *DataBagItem) Flatten() map[string]any {
+	flatten := make(map[string]any)
 	for key, v := range dbi.RawData {
 		subExpand := util.DeepMerge(key, v)
 		for k, u := range subExpand {

--- a/databag/mysql_funcs.go
+++ b/databag/mysql_funcs.go
@@ -23,7 +23,7 @@ import (
 
 // MySQL-specific functions for data bags & data bag items.
 
-func (db *DataBag) newDBItemMySQL(dbiID string, rawDbagItem map[string]interface{}) (*DataBagItem, error) {
+func (db *DataBag) newDBItemMySQL(dbiID string, rawDbagItem map[string]any) (*DataBagItem, error) {
 	rawb, rawerr := datastore.EncodeBlob(&rawDbagItem)
 	if rawerr != nil {
 		return nil, rawerr

--- a/databag/postgres_funcs.go
+++ b/databag/postgres_funcs.go
@@ -22,7 +22,7 @@ import (
 
 // PostgreSQL-specific functions for data bags & data bag items.
 
-func (db *DataBag) newDBItemPostgreSQL(dbiID string, rawDbagItem map[string]interface{}) (*DataBagItem, error) {
+func (db *DataBag) newDBItemPostgreSQL(dbiID string, rawDbagItem map[string]any) (*DataBagItem, error) {
 	rawb, rawerr := datastore.EncodeBlob(&rawDbagItem)
 	if rawerr != nil {
 		return nil, rawerr

--- a/databag/sql_funcs.go
+++ b/databag/sql_funcs.go
@@ -140,7 +140,7 @@ func (db *DataBag) getMultiDBItemSQL(dbItemNames []string) ([]*DataBagItem, erro
 		return nil, err
 	}
 	defer stmt.Close()
-	nameArgs := make([]interface{}, len(dbItemNames)+1)
+	nameArgs := make([]any, len(dbItemNames)+1)
 	nameArgs[0] = db.id
 	for i, v := range dbItemNames {
 		nameArgs[i+1] = v

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -76,7 +76,7 @@ type dsFileStore struct {
 }
 
 type dsItem struct {
-	Item interface{}
+	Item any
 }
 
 var dataStoreCache = initDataStore()
@@ -101,7 +101,7 @@ func (ds *DataStore) makeKey(keyType string, key string) string {
 }
 
 // Set a value of the given type with the provided key.
-func (ds *DataStore) Set(keyType string, key string, val interface{}) {
+func (ds *DataStore) Set(keyType string, key string, val any) {
 	dsKey := ds.makeKey(keyType, key)
 	ds.m.Lock()
 	defer ds.m.Unlock()
@@ -119,8 +119,8 @@ func (ds *DataStore) Set(keyType string, key string, val interface{}) {
 }
 
 // Get a value of the given type associated with the given key, if it exists.
-func (ds *DataStore) Get(keyType string, key string) (interface{}, bool) {
-	var val interface{}
+func (ds *DataStore) Get(keyType string, key string) (any, bool) {
+	var val any
 	var found bool
 
 	dsKey := ds.makeKey(keyType, key)
@@ -147,7 +147,7 @@ func (ds *DataStore) Get(keyType string, key string) (interface{}, bool) {
 	return val, found
 }
 
-func encodeSafeVal(val interface{}) ([]byte, error) {
+func encodeSafeVal(val any) ([]byte, error) {
 	valBuf := new(bytes.Buffer)
 	valItem := &dsItem{Item: val}
 	enc := gob.NewEncoder(valBuf)
@@ -159,7 +159,7 @@ func encodeSafeVal(val interface{}) ([]byte, error) {
 	return valBuf.Bytes(), nil
 }
 
-func decodeSafeVal(valEnc interface{}) (interface{}, error) {
+func decodeSafeVal(valEnc any) (any, error) {
 	valBuf := bytes.NewBuffer(valEnc.([]byte))
 	valItem := new(dsItem)
 	dec := gob.NewDecoder(valBuf)
@@ -213,7 +213,7 @@ func (ds *DataStore) GetList(keyType string) []string {
 }
 
 // SetNodeStatus updates a node's status using the in-memory data store.
-func (ds *DataStore) SetNodeStatus(nodeName string, obj interface{}, nsID ...int) error {
+func (ds *DataStore) SetNodeStatus(nodeName string, obj any, nsID ...int) error {
 	ds.m.Lock()
 	defer ds.m.Unlock()
 	ds.updated = true
@@ -221,9 +221,9 @@ func (ds *DataStore) SetNodeStatus(nodeName string, obj interface{}, nsID ...int
 	nsListKey := ds.makeKey("nodestatuslist", "nodestatuslists")
 	a, _ := ds.dsc.Get(nsKey)
 	if a == nil {
-		a = make(map[int]interface{})
+		a = make(map[int]any)
 	}
-	ns := a.(map[int]interface{})
+	ns := a.(map[int]any)
 	a, _ = ds.dsc.Get(nsListKey)
 	if a == nil {
 		a = make(map[string][]int)
@@ -254,7 +254,7 @@ func (ds *DataStore) SetNodeStatus(nodeName string, obj interface{}, nsID ...int
 // ReplaceNodeStatuses replaces the node statuses being stored in the data store
 // with the provided statuses that have been ordered by age already. This is
 // most useful when purging old statuses.
-func (ds *DataStore) ReplaceNodeStatuses(nodeName string, objs []interface{}) error {
+func (ds *DataStore) ReplaceNodeStatuses(nodeName string, objs []any) error {
 	ds.m.Lock()
 	defer ds.m.Unlock()
 	ds.updated = true
@@ -273,9 +273,9 @@ func (ds *DataStore) ReplaceNodeStatuses(nodeName string, objs []interface{}) er
 	nsListKey := ds.makeKey("nodestatuslist", "nodestatuslists")
 	a, _ := ds.dsc.Get(nsKey)
 	if a == nil {
-		a = make(map[int]interface{})
+		a = make(map[int]any)
 	}
-	ns := a.(map[int]interface{})
+	ns := a.(map[int]any)
 	a, _ = ds.dsc.Get(nsListKey)
 	if a == nil {
 		a = make(map[string][]int)
@@ -302,7 +302,7 @@ func (ds *DataStore) ReplaceNodeStatuses(nodeName string, objs []interface{}) er
 
 // AllNodeStatuses returns a list of all statuses known for the given node from
 // the in-memory data store.
-func (ds *DataStore) AllNodeStatuses(nodeName string) ([]interface{}, error) {
+func (ds *DataStore) AllNodeStatuses(nodeName string) ([]any, error) {
 	ds.m.RLock()
 	defer ds.m.RUnlock()
 	nsKey := ds.makeKey("nodestatus", "nodestatuses")
@@ -311,13 +311,13 @@ func (ds *DataStore) AllNodeStatuses(nodeName string) ([]interface{}, error) {
 	if a == nil {
 		return nil, ErrNoStatuses
 	}
-	ns := a.(map[int]interface{})
+	ns := a.(map[int]any)
 	a, _ = ds.dsc.Get(nsListKey)
 	if a == nil {
 		return nil, ErrNoStatusList
 	}
 	nslist := a.(map[string][]int)
-	arr := make([]interface{}, len(nslist[nodeName]))
+	arr := make([]any, len(nslist[nodeName]))
 	for i, v := range nslist[nodeName] {
 		if config.Config.UseUnsafeMemStore {
 			arr[i] = ns[v]
@@ -334,7 +334,7 @@ func (ds *DataStore) AllNodeStatuses(nodeName string) ([]interface{}, error) {
 
 // LatestNodeStatus returns the latest status for a node from the in-memory
 // data store.
-func (ds *DataStore) LatestNodeStatus(nodeName string) (interface{}, error) {
+func (ds *DataStore) LatestNodeStatus(nodeName string) (any, error) {
 	ds.m.RLock()
 	defer ds.m.RUnlock()
 	nsKey := ds.makeKey("nodestatus", "nodestatuses")
@@ -343,7 +343,7 @@ func (ds *DataStore) LatestNodeStatus(nodeName string) (interface{}, error) {
 	if a == nil {
 		return nil, ErrNoStatuses
 	}
-	ns := a.(map[int]interface{})
+	ns := a.(map[int]any)
 	a, _ = ds.dsc.Get(nsListKey)
 	if a == nil {
 		return nil, ErrNoStatusList
@@ -355,7 +355,7 @@ func (ds *DataStore) LatestNodeStatus(nodeName string) (interface{}, error) {
 		return nil, ErrorNodeStatus(err)
 	}
 	sort.Sort(sort.Reverse(sort.IntSlice(nsarr)))
-	var n interface{}
+	var n any
 	var err error
 
 	if config.Config.UseUnsafeMemStore {
@@ -386,7 +386,7 @@ func (ds *DataStore) deleteStatuses(nodeName string) error {
 	if a == nil {
 		return ErrNoStatuses
 	}
-	ns := a.(map[int]interface{})
+	ns := a.(map[int]any)
 	a, _ = ds.dsc.Get(nsListKey)
 	if a == nil {
 		return ErrNoStatusList
@@ -401,9 +401,9 @@ func (ds *DataStore) deleteStatuses(nodeName string) error {
 	return nil
 }
 
-func (ds *DataStore) getLogInfoMap() map[int]interface{} {
+func (ds *DataStore) getLogInfoMap() map[int]any {
 	dsKey := ds.makeKey("loginfo", "loginfos")
-	var a interface{}
+	var a any
 	if config.Config.UseUnsafeMemStore {
 		a, _ = ds.dsc.Get(dsKey)
 	} else {
@@ -417,13 +417,13 @@ func (ds *DataStore) getLogInfoMap() map[int]interface{} {
 		}
 	}
 	if a == nil {
-		a = make(map[int]interface{})
+		a = make(map[int]any)
 	}
-	arr := a.(map[int]interface{})
+	arr := a.(map[int]any)
 	return arr
 }
 
-func (ds *DataStore) setLogInfoMap(liMap map[int]interface{}) {
+func (ds *DataStore) setLogInfoMap(liMap map[int]any) {
 	dsKey := ds.makeKey("loginfo", "loginfos")
 	if config.Config.UseUnsafeMemStore {
 		ds.dsc.Set(dsKey, liMap, -1)
@@ -438,7 +438,7 @@ func (ds *DataStore) setLogInfoMap(liMap map[int]interface{}) {
 
 // SetLogInfo sets a loginfo in the data store. Unlike most of these objects,
 // log infos are stored and retrieved by id, since they have no useful names.
-func (ds *DataStore) SetLogInfo(obj interface{}, logID ...int) error {
+func (ds *DataStore) SetLogInfo(obj any, logID ...int) error {
 	ds.m.Lock()
 	defer ds.m.Unlock()
 	ds.updated = true
@@ -472,7 +472,7 @@ func (ds *DataStore) PurgeLogInfoBefore(id int) (int64, error) {
 	defer ds.m.Unlock()
 	ds.updated = true
 	arr := ds.getLogInfoMap()
-	newLogs := make(map[int]interface{})
+	newLogs := make(map[int]any)
 	var purged int64
 	for k, v := range arr {
 		if k > id {
@@ -485,7 +485,7 @@ func (ds *DataStore) PurgeLogInfoBefore(id int) (int64, error) {
 	return purged, nil
 }
 
-func getNextID(lis map[int]interface{}) int {
+func getNextID(lis map[int]any) int {
 	if len(lis) == 0 {
 		return 1
 	}
@@ -498,7 +498,7 @@ func getNextID(lis map[int]interface{}) int {
 }
 
 // GetLogInfo gets a loginfo by id.
-func (ds *DataStore) GetLogInfo(id int) (interface{}, error) {
+func (ds *DataStore) GetLogInfo(id int) (any, error) {
 	ds.m.RLock()
 	defer ds.m.RUnlock()
 	arr := ds.getLogInfoMap()
@@ -511,7 +511,7 @@ func (ds *DataStore) GetLogInfo(id int) (interface{}, error) {
 }
 
 // GetLogInfoList gets all the log infos currently stored.
-func (ds *DataStore) GetLogInfoList() map[int]interface{} {
+func (ds *DataStore) GetLogInfoList() map[int]any {
 	ds.m.RLock()
 	defer ds.m.RUnlock()
 	arr := ds.getLogInfoMap()
@@ -630,7 +630,7 @@ func (ds *DataStore) Load(dsFile string) error {
 // data structures, empty slices are encoded as "null" when they're sent out as
 // JSON to the client. This makes the client very unhappy, so those empty slices
 // need to be recreated again. Annoying, but it's how it goes.
-func ChkNilArray(obj interface{}) {
+func ChkNilArray(obj any) {
 	s := reflect.ValueOf(obj).Elem()
 	for i := 0; i < s.NumField(); i++ {
 		v := s.Field(i)
@@ -652,9 +652,9 @@ func ChkNilArray(obj interface{}) {
 // WalkMapForNil walks through the given map, searching for nil slices to create.
 // This does not handle all possible cases, but it *does* handle the cases found
 // with the chef objects in goiardi.
-func WalkMapForNil(r interface{}) interface{} {
+func WalkMapForNil(r any) any {
 	switch m := r.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for k, v := range m {
 			m[k] = WalkMapForNil(v)
 		}
@@ -666,9 +666,9 @@ func WalkMapForNil(r interface{}) interface{} {
 		}
 		r = m
 		return r
-	case []interface{}:
+	case []any:
 		if m == nil {
-			m = make([]interface{}, 0)
+			m = make([]any, 0)
 		}
 		r = m
 		return r

--- a/datastore/db.go
+++ b/datastore/db.go
@@ -42,20 +42,20 @@ const MySQLTimeFormat = "2006-01-02 15:04:05"
 // Dbhandle is an interface for db handle types that can execute queries.
 type Dbhandle interface {
 	Prepare(query string) (*sql.Stmt, error)
-	QueryRow(query string, args ...interface{}) *sql.Row
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-	Exec(query string, args ...interface{}) (sql.Result, error)
+	QueryRow(query string, args ...any) *sql.Row
+	Query(query string, args ...any) (*sql.Rows, error)
+	Exec(query string, args ...any) (sql.Result, error)
 }
 
 // ResRow is an interface for rows returned by Query, or a single row returned by
 // QueryRow. Used for passing in a db handle or a transaction to a function.
 type ResRow interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }
 
 // ConnectDB connects to a database with the database name and a map of
 // connection options. Currently supports MySQL and PostgreSQL.
-func ConnectDB(dbEngine string, params interface{}) (*sql.DB, error) {
+func ConnectDB(dbEngine string, params any) (*sql.DB, error) {
 	switch strings.ToLower(dbEngine) {
 	case "mysql", "postgres":
 		var connectStr string
@@ -88,7 +88,7 @@ func ConnectDB(dbEngine string, params interface{}) (*sql.DB, error) {
 }
 
 // EncodeToJSON encodes an object to a JSON string.
-func EncodeToJSON(obj interface{}) (string, error) {
+func EncodeToJSON(obj any) (string, error) {
 	buf := new(bytes.Buffer)
 	enc := json.NewEncoder(buf)
 	var err error
@@ -107,7 +107,7 @@ func EncodeToJSON(obj interface{}) (string, error) {
 // EncodeBlob encodes a slice or map of goiardi object data to save in the
 // database. Pass the object to be encoded in like
 // datastore.EncodeBlob(&foo.Thing).
-func EncodeBlob(obj interface{}) ([]byte, error) {
+func EncodeBlob(obj any) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	enc := json.NewEncoder(buf)
 	var err error
@@ -127,7 +127,7 @@ func EncodeBlob(obj interface{}) ([]byte, error) {
 // database so it can be loaded back into a goiardi object. The 'obj' in the
 // arguments *must* be the address of the object receiving the blob of data (e.g.
 // datastore.DecodeBlob(data, &obj).
-func DecodeBlob(data []byte, obj interface{}) error {
+func DecodeBlob(data []byte, obj any) error {
 	// hmmm
 	dbuf := bytes.NewBuffer(data)
 	dec := json.NewDecoder(dbuf)

--- a/datastore/mysql.go
+++ b/datastore/mysql.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 )
 
-func formatMysqlConStr(p interface{}) (string, error) {
+func formatMysqlConStr(p any) (string, error) {
 	params := p.(config.MySQLdb)
 	var (
 		userpass      string

--- a/datastore/postgresql.go
+++ b/datastore/postgresql.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-func formatPostgresqlConStr(p interface{}) string {
+func formatPostgresqlConStr(p any) string {
 	params := p.(config.PostgreSQLdb)
 	var conParams []string
 

--- a/depgraph/dependency.go
+++ b/depgraph/dependency.go
@@ -11,7 +11,7 @@ import (
 // that cannot be violated
 type Dependency struct {
 	Name        string
-	Meta        interface{}
+	Meta        any
 	Constraints []Constraint
 	Source      *Noun
 	Target      *Noun

--- a/depgraph/graph.go
+++ b/depgraph/graph.go
@@ -21,7 +21,7 @@ type WalkFunc func(*Noun) error
 // Graph is used to represent a dependency graph.
 type Graph struct {
 	Name  string
-	Meta  interface{}
+	Meta  any
 	Nouns []*Noun
 	Root  *Noun
 }

--- a/depgraph/noun.go
+++ b/depgraph/noun.go
@@ -11,7 +11,7 @@ import (
 // by depedencies.
 type Noun struct {
 	Name string // Opaque name
-	Meta interface{}
+	Meta any
 	Deps []*Dependency
 }
 

--- a/digraph/graphviz_test.go
+++ b/digraph/graphviz_test.go
@@ -2,6 +2,7 @@ package digraph
 
 import (
 	"bytes"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -36,11 +37,8 @@ b -> e
 
 	count := 0
 	for _, el := range expectedLines[1 : len(expectedLines)-1] {
-		for _, al := range actualLines[1 : len(actualLines)-1] {
-			if el == al {
-				count++
-				break
-			}
+		if slices.Contains(actualLines[1:len(actualLines)-1], el) {
+			count++
 		}
 	}
 

--- a/digraph/tarjan.go
+++ b/digraph/tarjan.go
@@ -1,5 +1,7 @@
 package digraph
 
+import "slices"
+
 // sccAcct is used ot pass around accounting information for
 // the StronglyConnectedComponents algorithm
 type sccAcct struct {
@@ -37,12 +39,7 @@ func (s *sccAcct) pop() Node {
 
 // inStack checks if a node is in the stack
 func (s *sccAcct) inStack(needle Node) bool {
-	for _, n := range s.Stack {
-		if n == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Stack, needle)
 }
 
 // StronglyConnectedComponents implements Tarjan's algorithm to
@@ -101,11 +98,4 @@ func stronglyConnected(acct *sccAcct, node Node) int {
 	}
 
 	return minIdx
-}
-
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -36,13 +36,13 @@ import (
 // ChefEnvironment is a collection of attributes and cookbook versions for
 // organizing how nodes are deployed.
 type ChefEnvironment struct {
-	Name             string                 `json:"name"`
-	ChefType         string                 `json:"chef_type"`
-	JSONClass        string                 `json:"json_class"`
-	Description      string                 `json:"description"`
-	Default          map[string]interface{} `json:"default_attributes"`
-	Override         map[string]interface{} `json:"override_attributes"`
-	CookbookVersions map[string]string      `json:"cookbook_versions"`
+	Name             string            `json:"name"`
+	ChefType         string            `json:"chef_type"`
+	JSONClass        string            `json:"json_class"`
+	Description      string            `json:"description"`
+	Default          map[string]any    `json:"default_attributes"`
+	Override         map[string]any    `json:"override_attributes"`
+	CookbookVersions map[string]string `json:"cookbook_versions"`
 }
 
 // New creates a new environment, returning an error if the environment already
@@ -76,15 +76,15 @@ func New(name string) (*ChefEnvironment, util.Gerror) {
 		Name:             name,
 		ChefType:         "environment",
 		JSONClass:        "Chef::Environment",
-		Default:          map[string]interface{}{},
-		Override:         map[string]interface{}{},
+		Default:          map[string]any{},
+		Override:         map[string]any{},
 		CookbookVersions: map[string]string{},
 	}
 	return env, nil
 }
 
 // NewFromJSON creates a new environment from JSON uploaded to the server.
-func NewFromJSON(jsonEnv map[string]interface{}) (*ChefEnvironment, util.Gerror) {
+func NewFromJSON(jsonEnv map[string]any) (*ChefEnvironment, util.Gerror) {
 	env, err := New(jsonEnv["name"].(string))
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func NewFromJSON(jsonEnv map[string]interface{}) (*ChefEnvironment, util.Gerror)
 
 // UpdateFromJSON updates an existing environment from JSON uploaded to the
 // server.
-func (e *ChefEnvironment) UpdateFromJSON(jsonEnv map[string]interface{}) util.Gerror {
+func (e *ChefEnvironment) UpdateFromJSON(jsonEnv map[string]any) util.Gerror {
 	if e.Name != jsonEnv["name"].(string) {
 		err := util.Errorf("Environment name %s and %s from JSON do not match", e.Name, jsonEnv["name"].(string))
 		return err
@@ -163,7 +163,7 @@ ValidElem:
 	if verr != nil {
 		return verr
 	}
-	for k, v := range jsonEnv["cookbook_versions"].(map[string]interface{}) {
+	for k, v := range jsonEnv["cookbook_versions"].(map[string]any) {
 		if !util.ValidateEnvName(k) || k == "" {
 			merr := util.Errorf("Cookbook name %s invalid", k)
 			merr.SetStatus(http.StatusBadRequest)
@@ -196,11 +196,11 @@ ValidElem:
 	e.ChefType = jsonEnv["chef_type"].(string)
 	e.JSONClass = jsonEnv["json_class"].(string)
 	e.Description = jsonEnv["description"].(string)
-	e.Default = jsonEnv["default_attributes"].(map[string]interface{})
-	e.Override = jsonEnv["override_attributes"].(map[string]interface{})
+	e.Default = jsonEnv["default_attributes"].(map[string]any)
+	e.Override = jsonEnv["override_attributes"].(map[string]any)
 	/* clear out, then loop over the cookbook versions */
-	e.CookbookVersions = make(map[string]string, len(jsonEnv["cookbook_versions"].(map[string]interface{})))
-	for c, v := range jsonEnv["cookbook_versions"].(map[string]interface{}) {
+	e.CookbookVersions = make(map[string]string, len(jsonEnv["cookbook_versions"].(map[string]any)))
+	for c, v := range jsonEnv["cookbook_versions"].(map[string]any) {
 		e.CookbookVersions[c] = v.(string)
 	}
 
@@ -230,7 +230,7 @@ func Get(envName string) (*ChefEnvironment, util.Gerror) {
 		}
 	} else {
 		ds := datastore.New()
-		var e interface{}
+		var e any
 		e, found = ds.Get("env", envName)
 		if e != nil {
 			env = e.(*ChefEnvironment)
@@ -314,8 +314,8 @@ func defaultEnvironment() *ChefEnvironment {
 		ChefType:         "environment",
 		JSONClass:        "Chef::Environment",
 		Description:      "The default Chef environment",
-		Default:          map[string]interface{}{},
-		Override:         map[string]interface{}{},
+		Default:          map[string]any{},
+		Override:         map[string]any{},
 		CookbookVersions: map[string]string{},
 	}
 }
@@ -394,8 +394,8 @@ func (e *ChefEnvironment) cookbookList() []*cookbook.Cookbook {
 
 // AllCookbookHash returns a hash of the cookbooks and their versions available
 // to this environment.
-func (e *ChefEnvironment) AllCookbookHash(numVersions interface{}) map[string]interface{} {
-	cbHash := make(map[string]interface{})
+func (e *ChefEnvironment) AllCookbookHash(numVersions any) map[string]any {
+	cbHash := make(map[string]any)
 	cbList := e.cookbookList()
 	for _, cb := range cbList {
 		if cb == nil {
@@ -447,7 +447,7 @@ func (e *ChefEnvironment) Index() string {
 }
 
 // Flatten the environment so it's suitable for indexing.
-func (e *ChefEnvironment) Flatten() map[string]interface{} {
+func (e *ChefEnvironment) Flatten() map[string]any {
 	return util.FlattenObj(e)
 }
 

--- a/environment/sql_funcs.go
+++ b/environment/sql_funcs.go
@@ -58,8 +58,8 @@ func (e *ChefEnvironment) fillEnvFromSQL(row datastore.ResRow) error {
 	e.ChefType = "environment"
 	e.JSONClass = "Chef::Environment"
 	if e.Name == "_default" {
-		e.Default = make(map[string]interface{})
-		e.Override = make(map[string]interface{})
+		e.Default = make(map[string]any)
+		e.Override = make(map[string]any)
 		e.CookbookVersions = make(map[string]string)
 		return nil
 	}
@@ -121,7 +121,7 @@ func getMultiSQL(envNames []string) ([]*ChefEnvironment, error) {
 		return nil, err
 	}
 	defer stmt.Close()
-	nameArgs := make([]interface{}, len(envNames))
+	nameArgs := make([]any, len(envNames))
 	for i, v := range envNames {
 		nameArgs[i] = v
 	}

--- a/environments.go
+++ b/environments.go
@@ -50,7 +50,7 @@ func environmentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pathArray := splitPath(r.URL.Path)
-	envResponse := make(map[string]interface{})
+	envResponse := make(map[string]any)
 	var numResults string
 	r.ParseForm()
 	if nrs, found := r.Form["num_versions"]; found {
@@ -310,8 +310,8 @@ func environmentHandler(w http.ResponseWriter, r *http.Request) {
 					// In 1.0.0-dev, there's a
 					// JSONErrorMapReport function in util.
 					// Use that when moving this forward
-					errMap := make(map[string][]map[string]interface{})
-					errMap["error"] = make([]map[string]interface{}, 1)
+					errMap := make(map[string][]map[string]any)
+					errMap["error"] = make([]map[string]any, 1)
 					errMap["error"][0] = derr.ErrMap()
 					w.WriteHeader(http.StatusPreconditionFailed)
 					logger.Infof("Cookbook Depends Errors in %s: %+v", env.Name, derr.ErrMap())

--- a/events.go
+++ b/events.go
@@ -132,9 +132,9 @@ func eventListHandler(w http.ResponseWriter, r *http.Request) {
 			jsonErrorReport(w, r, err.Error(), http.StatusBadRequest)
 			return
 		}
-		leResp := make([]map[string]interface{}, len(leList))
+		leResp := make([]map[string]any, len(leList))
 		for i, v := range leList {
-			leResp[i] = make(map[string]interface{})
+			leResp[i] = make(map[string]any)
 			leResp[i]["event"] = v
 			leURL := fmt.Sprintf("/events/%d", v.ID)
 			leResp[i]["url"] = util.CustomURL(leURL)

--- a/export.go
+++ b/export.go
@@ -44,7 +44,7 @@ type ExportData struct {
 	CreatedTime  time.Time
 	// It's a map of interfaces because the object structs may change
 	// between releases.
-	Data map[string][]interface{}
+	Data map[string][]any
 }
 
 // Major version number of the export file format.
@@ -59,7 +59,7 @@ const ExportMinorVersion = 1
 
 func exportAll(fileName string) error {
 	exportedData := &ExportData{MajorVersion: ExportMajorVersion, MinorVersion: ExportMinorVersion, CreatedTime: time.Now()}
-	exportedData.Data = make(map[string][]interface{})
+	exportedData.Data = make(map[string][]any)
 	// ... and march through everything.
 	exportedData.Data["client"] = client.ExportAllClients()
 	exportedData.Data["cookbook"] = exportTransformSlice(cookbook.AllCookbooks())
@@ -88,81 +88,81 @@ func exportAll(fileName string) error {
 	return nil
 }
 
-func exportTransformSlice(data interface{}) []interface{} {
-	var exp []interface{}
+func exportTransformSlice(data any) []any {
+	var exp []any
 	switch data := data.(type) {
 	case []*client.Client:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*user.User:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*cookbook.Cookbook:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*databag.DataBag:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*environment.ChefEnvironment:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*filestore.FileStore:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*loginfo.LogInfo:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*node.Node:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*report.Report:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*role.Role:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*sandbox.Sandbox:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*node.NodeStatus:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*shovey.Shovey:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*shovey.ShoveyRun:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}
 	case []*shovey.ShoveyRunStream:
-		exp = make([]interface{}, len(data))
+		exp = make([]any, len(data))
 		for i, v := range data {
 			exp[i] = v
 		}

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -108,7 +108,7 @@ func Get(chksum string) (*FileStore, error) {
 		}
 	} else {
 		ds := datastore.New()
-		var f interface{}
+		var f any
 		f, found = ds.Get("filestore", chksum)
 		if f != nil {
 			filestore = f.(*FileStore)

--- a/filestore/mysql_funcs.go
+++ b/filestore/mysql_funcs.go
@@ -52,7 +52,7 @@ func deleteHashesMySQL(fileHashes []string) {
 		log.Fatal(err)
 	}
 	deleteQuery := "DELETE FROM file_checksums WHERE checksum IN(?" + strings.Repeat(",?", len(fileHashes)-1) + ")"
-	delArgs := make([]interface{}, len(fileHashes))
+	delArgs := make([]any, len(fileHashes))
 	for i, v := range fileHashes {
 		delArgs[i] = v
 	}

--- a/gerror/error.go
+++ b/gerror/error.go
@@ -49,7 +49,7 @@ func New(text string) Error {
 }
 
 // Errorf creates a new Error, with a formatted error string.
-func Errorf(format string, a ...interface{}) Error {
+func Errorf(format string, a ...any) Error {
 	return New(fmt.Sprintf(format, a...))
 }
 

--- a/goiardi.go
+++ b/goiardi.go
@@ -35,6 +35,7 @@ import (
 	"os/signal"
 	"path"
 	"runtime"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -617,15 +618,15 @@ func gobRegister() {
 	gob.Register(r)
 	s := new(sandbox.Sandbox)
 	gob.Register(s)
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	gob.Register(m)
-	var si []interface{}
+	var si []any
 	gob.Register(si)
 	var ss []string
 	gob.Register(ss)
 	ms := make(map[string]string)
 	gob.Register(ms)
-	var smsi []map[string]interface{}
+	var smsi []map[string]any
 	gob.Register(smsi)
 	msss := make(map[string][]string)
 	gob.Register(msss)
@@ -635,7 +636,7 @@ func gobRegister() {
 	gob.Register(uu)
 	li := new(loginfo.LogInfo)
 	gob.Register(li)
-	mis := map[int]interface{}{}
+	mis := map[int]any{}
 	gob.Register(mis)
 	cbv := new(cookbook.CookbookVersion)
 	gob.Register(cbv)
@@ -734,7 +735,7 @@ func startEventMonitor(serfAddr string, errch chan<- error) {
 }
 
 func runEventMonitor(sc *serfclient.RPCClient, errch chan<- error) {
-	ch := make(chan map[string]interface{}, 10)
+	ch := make(chan map[string]any, 10)
 	sh, err := sc.Stream("*", ch)
 	if err != nil {
 		errch <- err
@@ -963,10 +964,5 @@ func initGeneralStatsd(metricsBackend met.Backend) {
 }
 
 func matchSupportedVersion(ver string) bool {
-	for _, v := range config.SupportedAPIVersions {
-		if ver == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(config.SupportedAPIVersions, ver)
 }

--- a/import.go
+++ b/import.go
@@ -61,11 +61,11 @@ func importAll(fileName string) error {
 		// load clients
 		logger.Infof("Loading clients")
 		for _, v := range exportedData.Data["client"] {
-			c, err := client.NewFromJSON(v.(map[string]interface{}))
+			c, err := client.NewFromJSON(v.(map[string]any))
 			if err != nil {
 				return err
 			}
-			pkerr := c.SetPublicKey(v.(map[string]interface{})["public_key"])
+			pkerr := c.SetPublicKey(v.(map[string]any)["public_key"])
 			if pkerr != nil {
 				return pkerr
 			}
@@ -78,14 +78,14 @@ func importAll(fileName string) error {
 		// load users
 		logger.Infof("Loading users")
 		for _, v := range exportedData.Data["user"] {
-			pwhash, _ := v.(map[string]interface{})["password"].(string)
-			v.(map[string]interface{})["password"] = ""
-			u, err := user.NewFromJSON(v.(map[string]interface{}))
+			pwhash, _ := v.(map[string]any)["password"].(string)
+			v.(map[string]any)["password"] = ""
+			u, err := user.NewFromJSON(v.(map[string]any))
 			if err != nil {
 				return err
 			}
 			u.SetPasswdHash(pwhash)
-			pkerr := u.SetPublicKey(v.(map[string]interface{})["public_key"])
+			pkerr := u.SetPublicKey(v.(map[string]any)["public_key"])
 			if pkerr != nil {
 				return pkerr
 			}
@@ -98,13 +98,13 @@ func importAll(fileName string) error {
 		// load filestore
 		logger.Infof("Loading filestore")
 		for _, v := range exportedData.Data["filestore"] {
-			fileData, err := base64.StdEncoding.DecodeString(v.(map[string]interface{})["Data"].(string))
+			fileData, err := base64.StdEncoding.DecodeString(v.(map[string]any)["Data"].(string))
 			if err != nil {
 				return err
 			}
 			fdBuf := bytes.NewBuffer(fileData)
 			fdRc := ioutil.NopCloser(fdBuf)
-			fs, err := filestore.New(v.(map[string]interface{})["Chksum"].(string), fdRc, int64(fdBuf.Len()))
+			fs, err := filestore.New(v.(map[string]any)["Chksum"].(string), fdRc, int64(fdBuf.Len()))
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ func importAll(fileName string) error {
 		// load cookbooks
 		logger.Infof("Loading cookbooks")
 		for _, v := range exportedData.Data["cookbook"] {
-			cb, err := cookbook.New(v.(map[string]interface{})["Name"].(string))
+			cb, err := cookbook.New(v.(map[string]any)["Name"].(string))
 			if err != nil {
 				return err
 			}
@@ -124,8 +124,8 @@ func importAll(fileName string) error {
 			if gerr != nil {
 				return gerr
 			}
-			for ver, cbvData := range v.(map[string]interface{})["Versions"].(map[string]interface{}) {
-				cbvData, cerr := checkAttrs(cbvData.(map[string]interface{}))
+			for ver, cbvData := range v.(map[string]any)["Versions"].(map[string]any) {
+				cbvData, cerr := checkAttrs(cbvData.(map[string]any))
 				if cerr != nil {
 					return cerr
 				}
@@ -139,7 +139,7 @@ func importAll(fileName string) error {
 		// load data bags
 		logger.Infof("Loading data bags")
 		for _, v := range exportedData.Data["data_bag"] {
-			dbag, err := databag.New(v.(map[string]interface{})["Name"].(string))
+			dbag, err := databag.New(v.(map[string]any)["Name"].(string))
 			if err != nil {
 				return err
 			}
@@ -147,8 +147,8 @@ func importAll(fileName string) error {
 			if gerr != nil {
 				return gerr
 			}
-			for _, dbagData := range v.(map[string]interface{})["DataBagItems"].(map[string]interface{}) {
-				_, dbierr := dbag.NewDBItem(dbagData.(map[string]interface{})["raw_data"].(map[string]interface{}))
+			for _, dbagData := range v.(map[string]any)["DataBagItems"].(map[string]any) {
+				_, dbierr := dbag.NewDBItem(dbagData.(map[string]any)["raw_data"].(map[string]any))
 				if dbierr != nil {
 					return dbierr
 				}
@@ -161,7 +161,7 @@ func importAll(fileName string) error {
 		// load environments
 		logger.Infof("Loading environments")
 		for _, v := range exportedData.Data["environment"] {
-			envData, cerr := checkAttrs(v.(map[string]interface{}))
+			envData, cerr := checkAttrs(v.(map[string]any))
 			if cerr != nil {
 				return nil
 			}
@@ -180,7 +180,7 @@ func importAll(fileName string) error {
 		// load nodes
 		logger.Infof("Loading nodes")
 		for _, v := range exportedData.Data["node"] {
-			nodeData, cerr := checkAttrs(v.(map[string]interface{}))
+			nodeData, cerr := checkAttrs(v.(map[string]any))
 			if cerr != nil {
 				return nil
 			}
@@ -197,7 +197,7 @@ func importAll(fileName string) error {
 		// load roles
 		logger.Infof("Loading roles")
 		for _, v := range exportedData.Data["role"] {
-			roleData, cerr := checkAttrs(v.(map[string]interface{}))
+			roleData, cerr := checkAttrs(v.(map[string]any))
 			if cerr != nil {
 				return nil
 			}
@@ -214,10 +214,10 @@ func importAll(fileName string) error {
 		// load sandboxes
 		logger.Infof("Loading sandboxes")
 		for _, v := range exportedData.Data["sandbox"] {
-			sbid, _ := v.(map[string]interface{})["Id"].(string)
-			sbts, _ := v.(map[string]interface{})["CreationTime"].(string)
-			sbcomplete, _ := v.(map[string]interface{})["Completed"].(bool)
-			sbck, _ := v.(map[string]interface{})["Checksums"].([]interface{})
+			sbid, _ := v.(map[string]any)["Id"].(string)
+			sbts, _ := v.(map[string]any)["CreationTime"].(string)
+			sbcomplete, _ := v.(map[string]any)["Completed"].(bool)
+			sbck, _ := v.(map[string]any)["Checksums"].([]any)
 			sbTime, err := time.Parse(time.RFC3339, sbts)
 			if err != nil {
 				return err
@@ -235,7 +235,7 @@ func importAll(fileName string) error {
 		// load loginfos
 		logger.Infof("Loading loginfo")
 		for _, v := range exportedData.Data["loginfo"] {
-			if err := loginfo.Import(v.(map[string]interface{})); err != nil {
+			if err := loginfo.Import(v.(map[string]any)); err != nil {
 				return err
 			}
 		}
@@ -245,7 +245,7 @@ func importAll(fileName string) error {
 		for _, o := range exportedData.Data["report"] {
 			// handle data exported from a bugged report export
 			var nodeName string
-			v := o.(map[string]interface{})
+			v := o.(map[string]any)
 			if n, ok := v["node_name"]; ok {
 				nodeName = n.(string)
 			} else if n, ok := v["nodeName"]; ok {
@@ -289,7 +289,7 @@ func importAll(fileName string) error {
 			// statuses
 			logger.Infof("Loading node statuses...")
 			for _, v := range exportedData.Data["node_status"] {
-				ns := v.(map[string]interface{})
+				ns := v.(map[string]any)
 				err := node.ImportStatus(ns)
 				if err != nil {
 					return err
@@ -297,7 +297,7 @@ func importAll(fileName string) error {
 			}
 			logger.Infof("Loading shoveys...")
 			for _, v := range exportedData.Data["shovey"] {
-				s := v.(map[string]interface{})
+				s := v.(map[string]any)
 				err := shovey.ImportShovey(s)
 				if err != nil {
 					return err
@@ -305,7 +305,7 @@ func importAll(fileName string) error {
 			}
 			logger.Infof("Loading shovey runs...")
 			for _, v := range exportedData.Data["shovey_run"] {
-				s := v.(map[string]interface{})
+				s := v.(map[string]any)
 				err := shovey.ImportShoveyRun(s)
 				if err != nil {
 					return err
@@ -314,7 +314,7 @@ func importAll(fileName string) error {
 			}
 			logger.Infof("Loading shovey run streams...")
 			for _, v := range exportedData.Data["shovey_run_stream"] {
-				s := v.(map[string]interface{})
+				s := v.(map[string]any)
 				err := shovey.ImportShoveyRunStream(s)
 				if err != nil {
 					return err

--- a/indexer/file_index.go
+++ b/indexer/file_index.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -617,10 +618,8 @@ func (idoc *IdxDoc) regexSearch(reTerm string) (bool, error) {
 	}
 	if n, _ := trie.HasPrefix(key); n != nil {
 		kids := n.ChildKeys()
-		for _, c := range kids {
-			if reComp.MatchString(c) {
-				return true, nil
-			}
+		if slices.ContainsFunc(kids, reComp.MatchString) {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -39,7 +39,7 @@ func init() {
 type Indexable interface {
 	DocID() string
 	Index() string
-	Flatten() map[string]interface{}
+	Flatten() map[string]any
 }
 
 // Index holds a map of document collections.
@@ -66,8 +66,7 @@ type ObjIndexer interface {
 	Clear() error
 }
 
-type Document interface {
-}
+type Document any
 
 var indexMap Index
 var objIndex ObjIndexer

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 type testObj struct {
-	Name    string                 `json:"name"`
-	URLType string                 `json:"url_type"`
-	Normal  map[string]interface{} `json:"normal"`
-	RunList []string               `json:"run_list"`
+	Name    string         `json:"name"`
+	URLType string         `json:"url_type"`
+	Normal  map[string]any `json:"normal"`
+	RunList []string       `json:"run_list"`
 }
 
 var conf *config.Conf
@@ -49,7 +49,7 @@ func (to *testObj) Index() string {
 	return "test_obj"
 }
 
-func (to *testObj) Flatten() map[string]interface{} {
+func (to *testObj) Flatten() map[string]any {
 	flatten := util.FlattenObj(to)
 	return flatten
 }

--- a/loginfo/log_info.go
+++ b/loginfo/log_info.go
@@ -15,7 +15,8 @@
  */
 
 /*
-Package loginfo tracks changes to objects when they're saved, noting the actor performing the action, what kind of action it was, the time of the change, the type of object and its id, and a dump of the object's state. */
+Package loginfo tracks changes to objects when they're saved, noting the actor performing the action, what kind of action it was, the time of the change, the type of object and its id, and a dump of the object's state.
+*/
 package loginfo
 
 import (
@@ -86,7 +87,7 @@ func LogEvent(doer actor.Actor, obj util.GoiardiObj, action string) error {
 	}
 	le.ActorInfo = actorInfo
 	if config.Config.SerfEventAnnounce {
-		qle := make(map[string]interface{}, 4)
+		qle := make(map[string]any, 4)
 		qle["time"] = le.Time
 		qle["action"] = le.Action
 		qle["object_type"] = le.ObjectType
@@ -101,7 +102,7 @@ func LogEvent(doer actor.Actor, obj util.GoiardiObj, action string) error {
 }
 
 // Import a log info event from an export dump.
-func Import(logData map[string]interface{}) error {
+func Import(logData map[string]any) error {
 	le := new(LogInfo)
 	le.Action = logData["action"].(string)
 	le.ActorType = logData["actor_type"].(string)
@@ -290,10 +291,7 @@ func GetLogInfos(searchParams map[string]string, limits ...int) ([]*LogInfo, err
 		return lis, nil
 	}
 	if len(limits) > 1 {
-		limit = offset + limit
-		if limit > len(lis) {
-			limit = len(lis)
-		}
+		limit = min(offset+limit, len(lis))
 	} else {
 		limit = len(lis)
 	}

--- a/loginfo/log_info_test.go
+++ b/loginfo/log_info_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestLogEvent(t *testing.T) {
-	k := make(map[int]interface{})
+	k := make(map[int]any)
 	gob.Register(k)
 	kk := new(LogInfo)
 	gob.Register(kk)

--- a/loginfo/sql_funcs.go
+++ b/loginfo/sql_funcs.go
@@ -59,7 +59,7 @@ func (le *LogInfo) importEventSQL() error {
 
 	aiBuf := bytes.NewBuffer([]byte(le.ActorInfo))
 	aiRC := ioutil.NopCloser(aiBuf)
-	doer := make(map[string]interface{})
+	doer := make(map[string]any)
 
 	dec := json.NewDecoder(aiRC)
 	dec.UseNumber()
@@ -209,7 +209,7 @@ func getLogInfoListSQL(searchParams map[string]string, from, until time.Time, li
 	var loggedEvents []*LogInfo
 
 	var sqlStmt string
-	sqlArgs := []interface{}{from, until}
+	sqlArgs := []any{from, until}
 	if config.Config.UseMySQL {
 		sqlStmt = "SELECT li.id, actor_type, actor_info, time, action, object_type, object_name, extended_info FROM log_infos li JOIN users u ON li.actor_id = u.id WHERE time >= ? AND time <= ?"
 		if action, ok := searchParams["action"]; ok {

--- a/node/mysql_funcs.go
+++ b/node/mysql_funcs.go
@@ -77,7 +77,7 @@ func (ns *NodeStatus) fillNodeStatusFromMySQL(row datastore.ResRow) error {
 func getNodesByStatusMySQL(nodeNames []string, status string) ([]*Node, error) {
 	var nodes []*Node
 	sqlStmt := "SELECT n.name, chef_environment, n.run_list, n.automatic_attr, n.normal_attr, n.default_attr, n.override_attr FROM node_latest_statuses n WHERE n.status = ? AND n.name IN(?" + strings.Repeat(",?", len(nodeNames)-1) + ")"
-	nodeArgs := make([]interface{}, len(nodeNames)+1)
+	nodeArgs := make([]any, len(nodeNames)+1)
 	nodeArgs[0] = status
 	for i, v := range nodeNames {
 		nodeArgs[i+1] = v

--- a/node/node.go
+++ b/node/node.go
@@ -30,15 +30,15 @@ import (
 
 // Node is a basic Chef node, holding the run list and attributes of the node.
 type Node struct {
-	Name            string                 `json:"name"`
-	ChefEnvironment string                 `json:"chef_environment"`
-	RunList         []string               `json:"run_list"`
-	JSONClass       string                 `json:"json_class"`
-	ChefType        string                 `json:"chef_type"`
-	Automatic       map[string]interface{} `json:"automatic"`
-	Normal          map[string]interface{} `json:"normal"`
-	Default         map[string]interface{} `json:"default"`
-	Override        map[string]interface{} `json:"override"`
+	Name            string         `json:"name"`
+	ChefEnvironment string         `json:"chef_environment"`
+	RunList         []string       `json:"run_list"`
+	JSONClass       string         `json:"json_class"`
+	ChefType        string         `json:"chef_type"`
+	Automatic       map[string]any `json:"automatic"`
+	Normal          map[string]any `json:"normal"`
+	Default         map[string]any `json:"default"`
+	Override        map[string]any `json:"override"`
 	isDown          bool
 }
 
@@ -77,16 +77,16 @@ func New(name string) (*Node, util.Gerror) {
 		ChefType:        "node",
 		JSONClass:       "Chef::Node",
 		RunList:         []string{},
-		Automatic:       map[string]interface{}{},
-		Normal:          map[string]interface{}{},
-		Default:         map[string]interface{}{},
-		Override:        map[string]interface{}{},
+		Automatic:       map[string]any{},
+		Normal:          map[string]any{},
+		Default:         map[string]any{},
+		Override:        map[string]any{},
 	}
 	return node, nil
 }
 
 // NewFromJSON creates a new node from the uploaded JSON.
-func NewFromJSON(jsonNode map[string]interface{}) (*Node, util.Gerror) {
+func NewFromJSON(jsonNode map[string]any) (*Node, util.Gerror) {
 	nodeName, nerr := util.ValidateAsString(jsonNode["name"])
 	if nerr != nil {
 		return nil, nerr
@@ -120,7 +120,7 @@ func Get(nodeName string) (*Node, util.Gerror) {
 		}
 	} else {
 		ds := datastore.New()
-		var n interface{}
+		var n any
 		n, found = ds.Get("node", nodeName)
 		if n != nil {
 			node = n.(*Node)
@@ -175,7 +175,7 @@ func GetMulti(nodeNames []string) ([]*Node, util.Gerror) {
 }
 
 // UpdateFromJSON updates an existing node with the uploaded JSON.
-func (n *Node) UpdateFromJSON(jsonNode map[string]interface{}) util.Gerror {
+func (n *Node) UpdateFromJSON(jsonNode map[string]any) util.Gerror {
 	/* It's actually totally legitimate to save a node with a different
 	 * name than you started with, but we need to get/create a new node for
 	 * it is all. */
@@ -265,10 +265,10 @@ ValidElem:
 	n.ChefType = jsonNode["chef_type"].(string)
 	n.JSONClass = jsonNode["json_class"].(string)
 	n.RunList = jsonNode["run_list"].([]string)
-	n.Normal = jsonNode["normal"].(map[string]interface{})
-	n.Automatic = jsonNode["automatic"].(map[string]interface{})
-	n.Default = jsonNode["default"].(map[string]interface{})
-	n.Override = jsonNode["override"].(map[string]interface{})
+	n.Normal = jsonNode["normal"].(map[string]any)
+	n.Automatic = jsonNode["automatic"].(map[string]any)
+	n.Default = jsonNode["default"].(map[string]any)
+	n.Override = jsonNode["override"].(map[string]any)
 	return nil
 }
 
@@ -359,7 +359,7 @@ func (n *Node) Index() string {
 }
 
 // Flatten a node for indexing.
-func (n *Node) Flatten() map[string]interface{} {
+func (n *Node) Flatten() map[string]any {
 	return util.FlattenObj(n)
 }
 

--- a/node/sql_funcs.go
+++ b/node/sql_funcs.go
@@ -126,7 +126,7 @@ func getMultiSQL(nodeNames []string) ([]*Node, error) {
 		return nil, err
 	}
 	defer stmt.Close()
-	nameArgs := make([]interface{}, len(nodeNames))
+	nameArgs := make([]any, len(nodeNames))
 	for i, v := range nodeNames {
 		nameArgs[i] = v
 	}

--- a/node/status.go
+++ b/node/status.go
@@ -68,8 +68,8 @@ func (n *Node) UpdateStatus(status string) error {
 
 // ImportStatus is used by the import function to import node statuses from the
 // exported JSON dump.
-func ImportStatus(nodeJSON map[string]interface{}) error {
-	n := nodeJSON["Node"].(map[string]interface{})
+func ImportStatus(nodeJSON map[string]any) error {
+	n := nodeJSON["Node"].(map[string]any)
 	status := nodeJSON["Status"].(string)
 	ut := nodeJSON["UpdatedAt"].(string)
 	updatedAt, err := time.Parse(time.RFC3339, ut)
@@ -240,7 +240,7 @@ func DeleteNodeStatusesByAge(dur time.Duration) (int, error) {
 		}
 		i := sort.Search(len(statuses), func(i int) bool { return statuses[i].UpdatedAt.After(cutoff) })
 		statuses = statuses[i:]
-		statusesIface := make([]interface{}, len(statuses))
+		statusesIface := make([]any, len(statuses))
 		for z, v := range statuses {
 			statusesIface[z] = v
 		}

--- a/principals.go
+++ b/principals.go
@@ -56,7 +56,7 @@ func principalHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			chefType = "client"
 		}
-		jsonPrincipal := map[string]interface{}{
+		jsonPrincipal := map[string]any{
 			"name":       chefActor.GetName(),
 			"type":       chefType,
 			"public_key": chefActor.PublicKey(),

--- a/report/report.go
+++ b/report/report.go
@@ -15,7 +15,8 @@
  */
 
 /*
-Package report implements reporting on client runs and node changes. See http://docs.opscode.com/reporting.html for details. CURRENTLY EXPERIMENTAL. */
+Package report implements reporting on client runs and node changes. See http://docs.opscode.com/reporting.html for details. CURRENTLY EXPERIMENTAL.
+*/
 package report
 
 import (
@@ -42,15 +43,15 @@ const ReportTimeFormat = "2006-01-02 15:04:05 -0700"
 // resources changed, what recipes were in the run list, and whether the run was
 // successful or not.
 type Report struct {
-	RunID          string                 `json:"run_id"`
-	StartTime      time.Time              `json:"start_time"`
-	EndTime        time.Time              `json:"end_time"`
-	TotalResCount  int                    `json:"total_res_count"`
-	Status         string                 `json:"status"`
-	RunList        string                 `json:"run_list"`
-	Resources      []interface{}          `json:"resources"`
-	Data           map[string]interface{} `json:"data"` // I think this is right
-	NodeName       string                 `json:"node_name"`
+	RunID          string         `json:"run_id"`
+	StartTime      time.Time      `json:"start_time"`
+	EndTime        time.Time      `json:"end_time"`
+	TotalResCount  int            `json:"total_res_count"`
+	Status         string         `json:"status"`
+	RunList        string         `json:"run_list"`
+	Resources      []any          `json:"resources"`
+	Data           map[string]any `json:"data"` // I think this is right
+	NodeName       string         `json:"node_name"`
 	organizationID int
 }
 
@@ -61,8 +62,8 @@ type privReport struct {
 	TotalResCount  *int
 	Status         *string
 	RunList        *string
-	Resources      *[]interface{}
-	Data           *map[string]interface{}
+	Resources      *[]any
+	Data           *map[string]any
 	NodeName       *string
 	OrganizationID *int
 }
@@ -138,7 +139,7 @@ func Get(runID string) (*Report, util.Gerror) {
 		}
 	} else {
 		ds := datastore.New()
-		var r interface{}
+		var r any
 		r, found = ds.Get("report", runID)
 		if r != nil {
 			report = r.(*Report)
@@ -205,7 +206,7 @@ func DeleteByAge(dur time.Duration) (int, error) {
 }
 
 // NewFromJSON creates a new report from the given uploaded JSON.
-func NewFromJSON(nodeName string, jsonReport map[string]interface{}) (*Report, util.Gerror) {
+func NewFromJSON(nodeName string, jsonReport map[string]any) (*Report, util.Gerror) {
 	rid, ok := jsonReport["run_id"].(string)
 	if !ok {
 		err := util.Errorf("invalid run id")
@@ -245,7 +246,7 @@ func NewFromJSON(nodeName string, jsonReport map[string]interface{}) (*Report, u
 }
 
 // UpdateFromJSON updates a report with the values in the uploaded JSON.
-func (r *Report) UpdateFromJSON(jsonReport map[string]interface{}) util.Gerror {
+func (r *Report) UpdateFromJSON(jsonReport map[string]any) util.Gerror {
 	if action, ok := jsonReport["action"].(string); ok {
 		if action != "end" {
 			err := util.Errorf("invalid action %s", action)
@@ -307,12 +308,12 @@ func (r *Report) UpdateFromJSON(jsonReport map[string]interface{}) util.Gerror {
 		err := util.Errorf("invalid run_list")
 		return err
 	}
-	_, ok = jsonReport["resources"].([]interface{})
+	_, ok = jsonReport["resources"].([]any)
 	if !ok {
 		err := util.Errorf("invalid resources %T", jsonReport["resources"])
 		return err
 	}
-	_, ok = jsonReport["data"].(map[string]interface{})
+	_, ok = jsonReport["data"].(map[string]any)
 	if !ok {
 		err := util.Errorf("invalid data")
 		return err
@@ -322,8 +323,8 @@ func (r *Report) UpdateFromJSON(jsonReport map[string]interface{}) util.Gerror {
 	r.TotalResCount = trc
 	r.Status = jsonReport["status"].(string)
 	r.RunList = jsonReport["run_list"].(string)
-	r.Resources = jsonReport["resources"].([]interface{})
-	r.Data = jsonReport["data"].(map[string]interface{})
+	r.Resources = jsonReport["resources"].([]any)
+	r.Data = jsonReport["data"].(map[string]any)
 	return nil
 }
 

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -43,12 +43,12 @@ func TestReportCreation(t *testing.T) {
 }
 
 func TestReportUpdating(t *testing.T) {
-	create := map[string]interface{}{"action": "start", "run_id": "12b8be8d-a2ef-4fc6-88b3-4c18103b88df", "start_time": "2014-05-10 01:05:42 +0000"}
+	create := map[string]any{"action": "start", "run_id": "12b8be8d-a2ef-4fc6-88b3-4c18103b88df", "start_time": "2014-05-10 01:05:42 +0000"}
 	//update := map[string]interface{}{"action":"end","resources":[],"status":"success","run_list":[],"total_res_count":"0","data":{},"start_time":"2014-05-10 01:05:42 +0000","end_time":"2014-05-10 01:05:42 +0000"}
-	update := map[string]interface{}{"action": "end", "status": "success", "start_time": "2014-05-10 01:05:42 +0000", "end_time": "2014-05-10 01:05:42 +0000", "total_res_count": "0"}
-	update["resources"] = make([]interface{}, 0)
+	update := map[string]any{"action": "end", "status": "success", "start_time": "2014-05-10 01:05:42 +0000", "end_time": "2014-05-10 01:05:42 +0000", "total_res_count": "0"}
+	update["resources"] = make([]any, 0)
 	update["run_list"] = "[]"
-	update["data"] = make(map[string]interface{})
+	update["data"] = make(map[string]any)
 	r, err := NewFromJSON("node", create)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/reports.go
+++ b/reports.go
@@ -62,7 +62,7 @@ func reportHandler(w http.ResponseWriter, r *http.Request) {
 
 	pathArray := splitPath(r.URL.Path)
 	pathArrayLen := len(pathArray)
-	reportResponse := make(map[string]interface{})
+	reportResponse := make(map[string]any)
 
 	switch r.Method {
 	case http.MethodHead:
@@ -182,7 +182,7 @@ func reportHandler(w http.ResponseWriter, r *http.Request) {
 		// Can't use the usual parseObjJSON function here, since
 		// the reporting "run_list" type is a string rather
 		// than []interface{}.
-		jsonReport := make(map[string]interface{})
+		jsonReport := make(map[string]any)
 		dec := json.NewDecoder(r.Body)
 		dec.UseNumber()
 		if jerr := dec.Decode(&jsonReport); jerr != nil {
@@ -241,11 +241,11 @@ func reportHandler(w http.ResponseWriter, r *http.Request) {
 
 // This function is subject to change, depending on what the client actually
 // expects. This may not be entirely correct.
-func formatRunShow(run *report.Report) map[string]interface{} {
+func formatRunShow(run *report.Report) map[string]any {
 	reportMap := util.MapifyObject(run)
 	resources := reportMap["resources"]
 	delete(reportMap, "resources")
-	reportFmt := make(map[string]interface{})
+	reportFmt := make(map[string]any)
 	reportFmt["run_detail"] = reportMap
 	reportFmt["resources"] = resources
 	return reportFmt

--- a/role/role.go
+++ b/role/role.go
@@ -34,14 +34,14 @@ import (
 
 // Role is a way to specify shared run lists and attributes for nodes.
 type Role struct {
-	Name        string                 `json:"name"`
-	ChefType    string                 `json:"chef_type"`
-	JSONClass   string                 `json:"json_class"`
-	RunList     []string               `json:"run_list"`
-	EnvRunLists map[string][]string    `json:"env_run_lists"`
-	Description string                 `json:"description"`
-	Default     map[string]interface{} `json:"default_attributes"`
-	Override    map[string]interface{} `json:"override_attributes"`
+	Name        string              `json:"name"`
+	ChefType    string              `json:"chef_type"`
+	JSONClass   string              `json:"json_class"`
+	RunList     []string            `json:"run_list"`
+	EnvRunLists map[string][]string `json:"env_run_lists"`
+	Description string              `json:"description"`
+	Default     map[string]any      `json:"default_attributes"`
+	Override    map[string]any      `json:"override_attributes"`
 }
 
 // New creates a new role.
@@ -75,15 +75,15 @@ func New(name string) (*Role, util.Gerror) {
 		JSONClass:   "Chef::Role",
 		RunList:     []string{},
 		EnvRunLists: map[string][]string{},
-		Default:     map[string]interface{}{},
-		Override:    map[string]interface{}{},
+		Default:     map[string]any{},
+		Override:    map[string]any{},
 	}
 
 	return role, nil
 }
 
 // NewFromJSON creates a new role from the uploaded JSON.
-func NewFromJSON(jsonRole map[string]interface{}) (*Role, util.Gerror) {
+func NewFromJSON(jsonRole map[string]any) (*Role, util.Gerror) {
 	role, err := New(jsonRole["name"].(string))
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func NewFromJSON(jsonRole map[string]interface{}) (*Role, util.Gerror) {
 }
 
 // UpdateFromJSON updates an existing role with the uploaded JSON.
-func (r *Role) UpdateFromJSON(jsonRole map[string]interface{}) util.Gerror {
+func (r *Role) UpdateFromJSON(jsonRole map[string]any) util.Gerror {
 	/* TODO - this and node.UpdateFromJSON may be generalizeable with
 	 * reflect - look into it. */
 	if r.Name != jsonRole["name"] {
@@ -179,8 +179,8 @@ ValidElem:
 	r.Description = jsonRole["description"].(string)
 	r.RunList = jsonRole["run_list"].([]string)
 	r.EnvRunLists = jsonRole["env_run_lists"].(map[string][]string)
-	r.Default = jsonRole["default_attributes"].(map[string]interface{})
-	r.Override = jsonRole["override_attributes"].(map[string]interface{})
+	r.Default = jsonRole["default_attributes"].(map[string]any)
+	r.Override = jsonRole["override_attributes"].(map[string]any)
 	return nil
 }
 
@@ -202,7 +202,7 @@ func Get(roleName string) (*Role, error) {
 		}
 	} else {
 		ds := datastore.New()
-		var r interface{}
+		var r any
 		r, found = ds.Get("role", roleName)
 		if r != nil {
 			role = r.(*Role)
@@ -320,7 +320,7 @@ func (r *Role) Index() string {
 }
 
 // Flatten a role so it's suitable for indexing.
-func (r *Role) Flatten() map[string]interface{} {
+func (r *Role) Flatten() map[string]any {
 	return util.FlattenObj(r)
 }
 

--- a/role/sql_funcs.go
+++ b/role/sql_funcs.go
@@ -113,7 +113,7 @@ func getMultiSQL(roleNames []string) ([]*Role, error) {
 		return nil, err
 	}
 	defer stmt.Close()
-	nameArgs := make([]interface{}, len(roleNames))
+	nameArgs := make([]any, len(roleNames))
 	for i, v := range roleNames {
 		nameArgs[i] = v
 	}

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -59,7 +59,7 @@ func (a ByDate) Less(i, j int) bool { return a[j].CreationTime.After(a[i].Creati
 
 // New creates a new sandbox, given a map of null values with file checksums as
 // keys.
-func New(checksumHash map[string]interface{}) (*Sandbox, error) {
+func New(checksumHash map[string]any) (*Sandbox, error) {
 	/* For some reason the checksums come in a JSON hash that looks like
 	 * this:
 	 * { "checksums": {
@@ -142,7 +142,7 @@ func Get(sandboxID string) (*Sandbox, error) {
 		}
 	} else {
 		ds := datastore.New()
-		var s interface{}
+		var s any
 		s, found = ds.Get("sandbox", sandboxID)
 		if s != nil {
 			sandbox = s.(*Sandbox)
@@ -200,11 +200,11 @@ func GetList() []string {
 
 // UploadChkList builds the list of file checksums and whether or not they need
 // to be uploaded. If they do, the upload URL is also provided.
-func (s *Sandbox) UploadChkList() map[string]map[string]interface{} {
+func (s *Sandbox) UploadChkList() map[string]map[string]any {
 	/* Uh... */
-	chksumStats := make(map[string]map[string]interface{})
+	chksumStats := make(map[string]map[string]any)
 	for _, chk := range s.Checksums {
-		chksumStats[chk] = make(map[string]interface{})
+		chksumStats[chk] = make(map[string]any)
 		var n bool
 		if config.Config.UseS3Upload {
 			n = util.S3CheckFile("default", chk)

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -60,8 +60,8 @@ func randStringBytesMaskImprSrc(n int) string {
 	return string(b)
 }
 
-func randomHashes(num int) map[string]interface{} {
-	h := make(map[string]interface{}, num)
+func randomHashes(num int) map[string]any {
+	h := make(map[string]any, num)
 	for i := 0; i < num; i++ {
 		s := randStringBytesMaskImprSrc(randStrLen)
 		chksum := md5.Sum([]byte(s))

--- a/sandboxes.go
+++ b/sandboxes.go
@@ -29,7 +29,7 @@ import (
 func sandboxHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	pathArray := splitPath(r.URL.Path)
-	sboxResponse := make(map[string]interface{})
+	sboxResponse := make(map[string]any)
 	opUser, oerr := reqctx.CtxReqUser(r.Context())
 	if oerr != nil {
 		jsonErrorReport(w, r, oerr.Error(), oerr.Status())
@@ -51,7 +51,7 @@ func sandboxHandler(w http.ResponseWriter, r *http.Request) {
 			jsonErrorReport(w, r, jerr.Error(), http.StatusBadRequest)
 			return
 		}
-		sboxHash, ok := jsonReq["checksums"].(map[string]interface{})
+		sboxHash, ok := jsonReq["checksums"].(map[string]any)
 		if !ok {
 			jsonErrorReport(w, r, "Field 'checksums' missing", http.StatusBadRequest)
 			return

--- a/search.go
+++ b/search.go
@@ -56,7 +56,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	 * go. */
 	w.Header().Set("Content-Type", "application/json")
 
-	searchResponse := make(map[string]interface{})
+	searchResponse := make(map[string]any)
 	pathArray := splitPath(r.URL.Path)
 	pathArrayLen := len(pathArray)
 
@@ -159,7 +159,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 			/* start figuring out what comes in POSTS now,
 			 * so the partial search tests don't complain
 			 * anymore. */
-			var partialData map[string]interface{}
+			var partialData map[string]any
 			if r.Method == http.MethodPost {
 				var perr error
 				partialData, perr = parseObjJSON(r.Body)
@@ -203,7 +203,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 
 func reindexHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	reindexResponse := make(map[string]interface{})
+	reindexResponse := make(map[string]any)
 	opUser, oerr := reqctx.CtxReqUser(r.Context())
 	if oerr != nil {
 		jsonErrorReport(w, r, oerr.Error(), oerr.Status())

--- a/search/postgres_search.go
+++ b/search/postgres_search.go
@@ -42,7 +42,7 @@ type PgQuery struct {
 	queryStrs  []string
 	arguments  []string
 	fullQuery  string
-	allArgs    []interface{}
+	allArgs    []any
 }
 
 type gClause struct {
@@ -50,7 +50,7 @@ type gClause struct {
 	op     Op
 }
 
-func (p *PostgresSearch) Search(idx string, q string, rows int, sortOrder string, start int, partialData map[string]interface{}) ([]map[string]interface{}, error) {
+func (p *PostgresSearch) Search(idx string, q string, rows int, sortOrder string, start int, partialData map[string]any) ([]map[string]any, error) {
 	// check that the endpoint actually exists
 	sqlStmt := "SELECT 1 FROM goiardi.search_collections WHERE organization_id = $1 AND name = $2"
 	stmt, serr := datastore.Dbh.Prepare(sqlStmt)
@@ -127,11 +127,11 @@ func (p *PostgresSearch) Search(idx string, q string, rows int, sortOrder string
 	// THE WRONG WAY:
 	// Eventually, ordering by the keys themselves would be awesome.
 	objs := getResults(idx, qresults)
-	res := make([]map[string]interface{}, len(objs))
+	res := make([]map[string]any, len(objs))
 	for i, r := range objs {
 		switch r := r.(type) {
 		case *client.Client:
-			jc := map[string]interface{}{
+			jc := map[string]any{
 				"name":       r.Name,
 				"chef_type":  r.ChefType,
 				"json_class": r.JSONClass,
@@ -174,10 +174,7 @@ func (p *PostgresSearch) Search(idx string, q string, rows int, sortOrder string
 	}
 	res = sortResults.res
 
-	end := start + rows
-	if end > len(res) {
-		end = len(res)
-	}
+	end := min(start+rows, len(res))
 	res = res[start:end]
 	return res, nil
 }
@@ -496,8 +493,8 @@ func binOp(op Op) string {
 	return opStr
 }
 
-func craftFullQuery(orgID int, idx string, paths []string, arguments []string, queryStrs []string, tNum *int) (string, []interface{}) {
-	allArgs := make([]interface{}, 0, len(paths)+len(arguments)+2)
+func craftFullQuery(orgID int, idx string, paths []string, arguments []string, queryStrs []string, tNum *int) (string, []any) {
+	allArgs := make([]any, 0, len(paths)+len(arguments)+2)
 	allArgs = append(allArgs, orgID)
 	allArgs = append(allArgs, idx)
 
@@ -560,7 +557,7 @@ func craftAltQueryPath(a, b string) string {
 	return util.PgSearchQueryKey(strings.Join([]string{a, b}, "."))
 }
 
-func searchQueryDebugf(format string, args ...interface{}) {
+func searchQueryDebugf(format string, args ...any) {
 	if config.Config.SearchQueryDebug {
 		logger.Debugf(format, args...)
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -39,12 +39,12 @@ import (
 // up to the Searcher to use whatever backend it wants to return the desired
 // results.
 type Searcher interface {
-	Search(string, string, int, string, int, map[string]interface{}) ([]map[string]interface{}, error)
+	Search(string, string, int, string, int, map[string]any) ([]map[string]any, error)
 	GetEndpoints() []string
 }
 
 type results struct {
-	res     []map[string]interface{}
+	res     []map[string]any
 	sortKey string
 }
 
@@ -98,7 +98,7 @@ type TrieSearch struct {
 
 // Search parses the given query string and search the given index for any
 // matching results.
-func (t *TrieSearch) Search(idx string, query string, rows int, sortOrder string, start int, partialData map[string]interface{}) ([]map[string]interface{}, error) {
+func (t *TrieSearch) Search(idx string, query string, rows int, sortOrder string, start int, partialData map[string]any) ([]map[string]any, error) {
 	defer trackSearchTiming(time.Now(), query, inMemSearchTimings)
 	m.Lock()
 	defer m.Unlock()
@@ -118,11 +118,11 @@ func (t *TrieSearch) Search(idx string, query string, rows int, sortOrder string
 	}
 	qresults := solrQ.results()
 	objs := getResults(idx, qresults)
-	res := make([]map[string]interface{}, len(objs))
+	res := make([]map[string]any, len(objs))
 	for i, r := range objs {
 		switch r := r.(type) {
 		case *client.Client:
-			jc := map[string]interface{}{
+			jc := map[string]any{
 				"name":       r.Name,
 				"chef_type":  r.ChefType,
 				"json_class": r.JSONClass,
@@ -164,10 +164,7 @@ func (t *TrieSearch) Search(idx string, query string, rows int, sortOrder string
 	}
 	res = sortResults.res
 
-	end := start + rows
-	if end > len(res) {
-		end = len(res)
-	}
+	end := min(start+rows, len(res))
 	res = res[start:end]
 	return res, nil
 }
@@ -324,12 +321,12 @@ func getResults(variety string, toGet []string) []indexer.Indexable {
 	return results
 }
 
-func partialSearchFormat(results []map[string]interface{}, partialFormat map[string]interface{}) ([]map[string]interface{}, error) {
+func partialSearchFormat(results []map[string]any, partialFormat map[string]any) ([]map[string]any, error) {
 	/* regularize partial search keys */
 	psearchKeys := make(map[string][]string, len(partialFormat))
 	for k, v := range partialFormat {
 		switch v := v.(type) {
-		case []interface{}:
+		case []any:
 			psearchKeys[k] = make([]string, len(v))
 			for i, j := range v {
 				switch j := j.(type) {
@@ -350,12 +347,12 @@ func partialSearchFormat(results []map[string]interface{}, partialFormat map[str
 			return nil, err
 		}
 	}
-	newResults := make([]map[string]interface{}, len(results))
+	newResults := make([]map[string]any, len(results))
 
 	for i, j := range results {
-		newResults[i] = make(map[string]interface{})
+		newResults[i] = make(map[string]any)
 		for key, vals := range psearchKeys {
-			var pval interface{}
+			var pval any
 			/* The first key can either be top or first level.
 			 * Annoying, but that's how it is. */
 			if len(vals) > 0 {
@@ -375,10 +372,10 @@ func partialSearchFormat(results []map[string]interface{}, partialFormat map[str
 							tval := walk(j[r], vals[0:])
 							if tval != nil {
 								switch pv := pval.(type) {
-								case map[string]interface{}:
+								case map[string]any:
 									// only merge if tval is also a map[string]interface{}
 									switch tval := tval.(type) {
-									case map[string]interface{}:
+									case map[string]any:
 										for g, h := range tval {
 											pv[g] = h
 										}
@@ -398,9 +395,9 @@ func partialSearchFormat(results []map[string]interface{}, partialFormat map[str
 	return newResults, nil
 }
 
-func walk(v interface{}, keys []string) interface{} {
+func walk(v any, keys []string) any {
 	switch v := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		if _, found := v[keys[0]]; found {
 			if len(keys) > 1 {
 				return walk(v[keys[0]], keys[1:])
@@ -420,14 +417,14 @@ func walk(v interface{}, keys []string) interface{} {
 	}
 }
 
-func formatPartials(results []map[string]interface{}, objs []indexer.Indexable, partialData map[string]interface{}) ([]map[string]interface{}, error) {
+func formatPartials(results []map[string]any, objs []indexer.Indexable, partialData map[string]any) ([]map[string]any, error) {
 	var err error
 	results, err = partialSearchFormat(results, partialData)
 	if err != nil {
 		return nil, err
 	}
 	for x, z := range results {
-		tmpRes := make(map[string]interface{})
+		tmpRes := make(map[string]any)
 		switch ro := objs[x].(type) {
 		case *databag.DataBagItem:
 			dbiURL := fmt.Sprintf("/data/%s/%s", ro.DataBagName, ro.RawData["id"].(string))

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -87,7 +87,7 @@ func makeSearchItems() int {
 		clients[i].Save()
 		dbags[i], _ = databag.New(fmt.Sprintf("databag%d", i))
 		dbags[i].Save()
-		dbi := make(map[string]interface{})
+		dbi := make(map[string]any)
 		dbi["id"] = fmt.Sprintf("dbi%d", i)
 		dbi["foo"] = fmt.Sprintf("dbag_item_%d", i)
 		dbi["mac"] = fmt.Sprintf("01:02:03:04:05:%02d", i)
@@ -104,7 +104,7 @@ func makeSearchItems() int {
 	dbagunic, _ = databag.New("unicode")
 	dbagunic.Save()
 	for k := 0; k < 500; k++ {
-		dbu := make(map[string]interface{})
+		dbu := make(map[string]any)
 		dbu["id"] = fmt.Sprintf("dbagunic%d", k)
 		dbu["foo"] = fmt.Sprintf("dbagunic_thingamagic_%d", k)
 		dbu["blè"] = "üüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüü"

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -25,7 +25,7 @@ import (
 
 type ActorKeyer interface {
 	PublicKey() string
-	SetPublicKey(interface{}) error
+	SetPublicKey(any) error
 	util.GoiardiObj
 }
 

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -1,3 +1,4 @@
+//go:build !novault
 // +build !novault
 
 /*
@@ -86,7 +87,7 @@ func (k *keyer) PublicKey() string {
 	return ""
 }
 
-func (k *keyer) SetPublicKey(i interface{}) error {
+func (k *keyer) SetPublicKey(i any) error {
 	return nil
 }
 
@@ -142,7 +143,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("error setting up vault client: %s", err.Error())
 	}
-	_, err = cl.Logical().Write(signingPath, map[string]interface{}{
+	_, err = cl.Logical().Write(signingPath, map[string]any{
 		"RSAKey": signingKey,
 	})
 	if err != nil {

--- a/secret/vault.go
+++ b/secret/vault.go
@@ -1,3 +1,4 @@
+//go:build !novault
 // +build !novault
 
 /*
@@ -55,10 +56,10 @@ type secretVal struct {
 	stale         bool
 	staleTryAgain time.Time
 	staleTime     time.Time
-	value         interface{}
+	value         any
 }
 
-type secretConvert func(interface{}) (interface{}, error)
+type secretConvert func(any) (any, error)
 
 func configureVault() (*vaultSecretStore, error) {
 	conf := vault.DefaultConfig()
@@ -78,7 +79,7 @@ func configureVault() (*vaultSecretStore, error) {
 	return v, nil
 }
 
-func (v *vaultSecretStore) getSecret(path string, secretType string) (interface{}, error) {
+func (v *vaultSecretStore) getSecret(path string, secretType string) (any, error) {
 	if v.secrets[path] == nil {
 		logger.Debugf("secret (%s) for %s is nil, fetching from vault", secretType, path)
 		s, err := v.getSecretPath(path, secretType)
@@ -116,10 +117,10 @@ func (v *vaultSecretStore) getSecretPath(path string, secretType string) (*secre
 	return sVal, nil
 }
 
-func (v *vaultSecretStore) setSecret(path string, secretType string, value interface{}) error {
+func (v *vaultSecretStore) setSecret(path string, secretType string, value any) error {
 	logger.Debugf("setting public key for %s (%s)", path, secretType)
 	t := time.Now()
-	_, err := v.Logical().Write(path, map[string]interface{}{
+	_, err := v.Logical().Write(path, map[string]any{
 		secretType: value,
 	})
 	if err != nil {
@@ -189,7 +190,7 @@ func makeHashPath(c ActorKeyer) string {
 	return fmt.Sprintf("keys/passwd/%s/%s", c.URLType(), c.GetName())
 }
 
-func newSecretVal(path string, secretType string, value interface{}, t time.Time, s *vault.Secret) *secretVal {
+func newSecretVal(path string, secretType string, value any, t time.Time, s *vault.Secret) *secretVal {
 	sVal := new(secretVal)
 	sVal.path = path
 	sVal.secretType = secretType
@@ -208,7 +209,7 @@ func (s *secretVal) isExpired() bool {
 	return time.Now().After(s.expires)
 }
 
-func (v *vaultSecretStore) secretValue(s *secretVal) (interface{}, error) {
+func (v *vaultSecretStore) secretValue(s *secretVal) (any, error) {
 	if s.isExpired() {
 		logger.Debugf("trying to renew secret for %s", s.path)
 		s2, err := v.getSecretPath(s.path, s.secretType)
@@ -314,11 +315,11 @@ func (v *vaultSecretStore) deletePasswdHash(c ActorKeyer) error {
 
 // funcs to process secrets after fetching them from vault
 
-func secretPassThrough(i interface{}) (interface{}, error) {
+func secretPassThrough(i any) (any, error) {
 	return i, nil
 }
 
-func secretRSAKey(i interface{}) (interface{}, error) {
+func secretRSAKey(i any) (any, error) {
 	p, ok := i.(string)
 	if !ok {
 		return nil, fmt.Errorf("not an RSA private key in string form")

--- a/serfin/serfin.go
+++ b/serfin/serfin.go
@@ -149,7 +149,7 @@ func CloseSerfClient(serfAddr string) {
 }
 
 // SendEvent sends a serf event out from goiardi.
-func SendEvent(eventName string, payload interface{}) {
+func SendEvent(eventName string, payload any) {
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
 		logger.Errorf(err.Error())
@@ -163,7 +163,7 @@ func SendEvent(eventName string, payload interface{}) {
 }
 
 // SendQuery sends a basic, no frills query out over serf.
-func SendQuery(queryName string, payload interface{}) {
+func SendQuery(queryName string, payload any) {
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
 		logger.Errorf(err.Error())

--- a/shovey.go
+++ b/shovey.go
@@ -54,7 +54,7 @@ func shoveyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	op := pathArray[1]
 
-	shoveyResponse := make(map[string]interface{})
+	shoveyResponse := make(map[string]any)
 
 	switch op {
 	case "jobs":
@@ -132,7 +132,7 @@ func shoveyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			var nodeNames []string
 
-			if shvNodes, ok := shvData["nodes"].([]interface{}); ok {
+			if shvNodes, ok := shvData["nodes"].([]any); ok {
 				if len(shvNodes) == 0 {
 					jsonErrorReport(w, r, "no nodes provided", http.StatusBadRequest)
 					return
@@ -179,7 +179,7 @@ func shoveyHandler(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				if nn, ok := cancelData["nodes"].([]interface{}); ok {
+				if nn, ok := cancelData["nodes"].([]any); ok {
 					for _, v := range nn {
 						nodeNames = append(nodeNames, v.(string))
 					}

--- a/shovey/shovey.go
+++ b/shovey/shovey.go
@@ -110,7 +110,7 @@ func newQuerror(text string) Qerror {
 }
 
 // Errorf creates a new Qerror, with a formatted error string.
-func Errorf(format string, a ...interface{}) Qerror {
+func Errorf(format string, a ...any) Qerror {
 	return newQuerror(fmt.Sprintf(format, a...))
 }
 
@@ -528,8 +528,8 @@ func (s *Shovey) checkCompleted() {
 }
 
 // ToJSON formats a shovey instance to render as JSON for the client.
-func (s *Shovey) ToJSON() (map[string]interface{}, util.Gerror) {
-	toJSON := make(map[string]interface{})
+func (s *Shovey) ToJSON() (map[string]any, util.Gerror) {
+	toJSON := make(map[string]any)
 	toJSON["id"] = s.RunID
 	toJSON["command"] = s.Command
 	toJSON["run_timeout"] = s.Timeout
@@ -619,7 +619,7 @@ func AllShoveyRunStreams() []*ShoveyRunStream {
 }
 
 // UpdateFromJSON updates a ShoveyRun with the given JSON from the client.
-func (sr *ShoveyRun) UpdateFromJSON(srData map[string]interface{}) util.Gerror {
+func (sr *ShoveyRun) UpdateFromJSON(srData map[string]any) util.Gerror {
 	if status, ok := srData["status"].(string); ok {
 		if status == "invalid" || status == "succeeded" || status == "failed" || status == "nacked" {
 			sr.EndTime = time.Now()
@@ -706,9 +706,9 @@ func (sr *ShoveyRun) CombineStreamOutput(outputType string, seq int) (string, ut
 }
 
 // ToJSON formats a ShoveyRun for marshalling as JSON.
-func (sr *ShoveyRun) ToJSON() (map[string]interface{}, util.Gerror) {
+func (sr *ShoveyRun) ToJSON() (map[string]any, util.Gerror) {
 	var err util.Gerror
-	toJSON := make(map[string]interface{})
+	toJSON := make(map[string]any)
 	toJSON["run_id"] = sr.ShoveyUUID
 	toJSON["node_name"] = sr.NodeName
 	toJSON["status"] = sr.Status
@@ -799,9 +799,9 @@ func (s *Shovey) signRequest(payload map[string]string) (string, error) {
 }
 
 // ImportShovey is used to import shovey jobs from the exported JSON dump.
-func ImportShovey(shoveyJSON map[string]interface{}) error {
+func ImportShovey(shoveyJSON map[string]any) error {
 	runID := shoveyJSON["id"].(string)
-	nn := shoveyJSON["nodes"].([]interface{})
+	nn := shoveyJSON["nodes"].([]any)
 	nodeNames := make([]string, len(nn))
 	for i, v := range nn {
 		nodeNames[i] = v.(string)
@@ -826,7 +826,7 @@ func ImportShovey(shoveyJSON map[string]interface{}) error {
 }
 
 // ImportShoveyRun is used to import shovey jobs from the exported JSON dump.
-func ImportShoveyRun(sRunJSON map[string]interface{}) error {
+func ImportShoveyRun(sRunJSON map[string]any) error {
 	shoveyUUID := sRunJSON["run_id"].(string)
 	nodeName := sRunJSON["node_name"].(string)
 	status := sRunJSON["status"].(string)
@@ -853,7 +853,7 @@ func ImportShoveyRun(sRunJSON map[string]interface{}) error {
 
 // ImportShoveyRunStream is used to import shovey jobs from the exported JSON
 // dump.
-func ImportShoveyRunStream(srStreamJSON map[string]interface{}) error {
+func ImportShoveyRunStream(srStreamJSON map[string]any) error {
 	shoveyUUID := srStreamJSON["ShoveyUUID"].(string)
 	nodeName := srStreamJSON["NodeName"].(string)
 	seqtmp, _ := intify(srStreamJSON["Seq"])
@@ -893,7 +893,7 @@ func (s BySeq) Len() int           { return len(s) }
 func (s BySeq) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s BySeq) Less(i, j int) bool { return s[i].Seq < s[j].Seq }
 
-func intify(i interface{}) (int64, bool) {
+func intify(i any) (int64, bool) {
 	var retint int64
 	var ok bool
 

--- a/status.go
+++ b/status.go
@@ -43,7 +43,7 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var statusResponse interface{}
+	var statusResponse any
 
 	switch r.Method {
 	case http.MethodHead:

--- a/user/user.go
+++ b/user/user.go
@@ -272,7 +272,7 @@ func (u *User) Rename(newName string) util.Gerror {
 }
 
 // NewFromJSON builds a new user from a JSON object.
-func NewFromJSON(jsonUser map[string]interface{}) (*User, util.Gerror) {
+func NewFromJSON(jsonUser map[string]any) (*User, util.Gerror) {
 	userName, nerr := util.ValidateAsString(jsonUser["name"])
 	if nerr != nil {
 		return nil, nerr
@@ -296,7 +296,7 @@ func NewFromJSON(jsonUser map[string]interface{}) (*User, util.Gerror) {
 
 // UpdateFromJSON updates a user from a JSON object, carrying out a bunch of
 // validations inside.
-func (u *User) UpdateFromJSON(jsonUser map[string]interface{}) util.Gerror {
+func (u *User) UpdateFromJSON(jsonUser map[string]any) util.Gerror {
 	userName, nerr := util.ValidateAsString(jsonUser["name"])
 	if nerr != nil {
 		return nerr
@@ -387,8 +387,8 @@ func GetList() []string {
 // ToJSON converts the user to a JSON object, massaging it as needed to keep
 // the chef client happy (be it knife, chef-pedant, etc.) NOTE: There may be a
 // more idiomatic way to do this.
-func (u *User) ToJSON() map[string]interface{} {
-	toJSON := make(map[string]interface{})
+func (u *User) ToJSON() map[string]any {
+	toJSON := make(map[string]any)
 	toJSON["name"] = u.Name
 	toJSON["admin"] = u.Admin
 	toJSON["public_key"] = u.PublicKey()
@@ -431,7 +431,7 @@ func (u *User) GenerateKeys() (string, error) {
 
 // ValidatePublicKey checks that the provided public key is valid. Wrapper
 // around chefcrypto.ValidatePublicKey(), but with a different error type.
-func ValidatePublicKey(publicKey interface{}) (bool, util.Gerror) {
+func ValidatePublicKey(publicKey any) (bool, util.Gerror) {
 	ok, pkerr := chefcrypto.ValidatePublicKey(publicKey)
 	var err util.Gerror
 	if !ok {
@@ -457,7 +457,7 @@ func (u *User) IsValidator() bool {
 
 // IsSelf returns true if the actor in question s the same client or user as the
 // caller. Always returns true if use-auth is false.
-func (u *User) IsSelf(other interface{}) bool {
+func (u *User) IsSelf(other any) bool {
 	if !config.Config.UseAuth {
 		return true
 	}
@@ -495,7 +495,7 @@ func (u *User) PublicKey() string {
 }
 
 // SetPublicKey does what it says on the tin. Part of the Actor interface.
-func (u *User) SetPublicKey(pk interface{}) error {
+func (u *User) SetPublicKey(pk any) error {
 	switch pk := pk.(type) {
 	case string:
 		ok, err := ValidatePublicKey(pk)
@@ -519,7 +519,7 @@ func (u *User) SetPublicKey(pk interface{}) error {
 
 // CheckPermEdit checks to see if the user is trying to edit admin and
 // validator attributes, and if it has permissions to do so.
-func (u *User) CheckPermEdit(userData map[string]interface{}, perm string) util.Gerror {
+func (u *User) CheckPermEdit(userData map[string]any, perm string) util.Gerror {
 	gerr := util.Errorf("You are not allowed to take this action.")
 	gerr.SetStatus(http.StatusForbidden)
 
@@ -647,9 +647,9 @@ func AllUsers() []*User {
 }
 
 // ExportAllUsers return all users, in a fashion suitable for exporting.
-func ExportAllUsers() []interface{} {
+func ExportAllUsers() []any {
 	users := AllUsers()
-	export := make([]interface{}, len(users))
+	export := make([]any, len(users))
 	for i, u := range users {
 		export[i] = u.export()
 	}

--- a/util/strings.go
+++ b/util/strings.go
@@ -28,7 +28,7 @@ import (
 type StringSlice []string
 
 // Scan implements sql.Scanner for the StringSlice type.
-func (s *StringSlice) Scan(src interface{}) error {
+func (s *StringSlice) Scan(src any) error {
 	asBytes, ok := src.([]byte)
 	if !ok {
 		return error(gerror.New("Scan source was not []bytes"))

--- a/util/util.go
+++ b/util/util.go
@@ -75,7 +75,7 @@ type Gerror interface {
 
 // Errorf creates a new Gerror, with a formatted error string. A convenience
 // wrapper around error.Errorf.
-func Errorf(format string, a ...interface{}) Gerror {
+func Errorf(format string, a ...any) Gerror {
 	return gerror.Errorf(format, a...)
 }
 
@@ -114,9 +114,9 @@ func chkPath(p *string) {
 // it's suitable for indexing, either with solr (eventually) or with the whipped
 // up replacement for local mode. Objects fed into this function *must* have the
 // "json" tag set for their struct members.
-func FlattenObj(obj interface{}) map[string]interface{} {
+func FlattenObj(obj any) map[string]any {
 	s := reflect.ValueOf(obj).Elem()
-	expanded := make(map[string]interface{}, s.NumField())
+	expanded := make(map[string]any, s.NumField())
 
 	for i := 0; i < s.NumField(); i++ {
 		if !s.Field(i).CanInterface() {
@@ -142,8 +142,8 @@ func FlattenObj(obj interface{}) map[string]interface{} {
 // MapifyObject turns an object into a map[string]interface{}. Useful for when
 // you have a slice of objects that you need to trim, mutilate, fold, etc.
 // before returning them as JSON.
-func MapifyObject(obj interface{}) map[string]interface{} {
-	mapified := make(map[string]interface{})
+func MapifyObject(obj any) map[string]any {
+	mapified := make(map[string]any)
 	s := reflect.ValueOf(obj).Elem()
 	for i := 0; i < s.NumField(); i++ {
 		if !s.Field(i).CanInterface() {
@@ -158,7 +158,7 @@ func MapifyObject(obj interface{}) map[string]interface{} {
 
 // Indexify prepares a flattened object for indexing by turning it into a sorted
 // slice of strings formatted like "key:value".
-func Indexify(flattened map[string]interface{}) []string {
+func Indexify(flattened map[string]any) []string {
 	var readyToIndex []string
 	// keep values in the index down to a reasonable size
 	maxValLen := config.Config.IndexValTrim
@@ -198,7 +198,7 @@ func IndexEscapeStr(s string) string {
 }
 
 // DeepMerge merges disparate data structures into a flat hash.
-func DeepMerge(key string, source interface{}) map[string]interface{} {
+func DeepMerge(key string, source any) map[string]any {
 	refIface := reflect.ValueOf(source)
 	var mapCap int
 	if refIface.Kind() == reflect.Map {
@@ -207,7 +207,7 @@ func DeepMerge(key string, source interface{}) map[string]interface{} {
 		mapCap = defaultMapCap
 	}
 
-	merger := make(map[string]interface{}, mapCap)
+	merger := make(map[string]any, mapCap)
 	var sep string
 	if config.Config.DotSearch {
 		sep = "."
@@ -215,7 +215,7 @@ func DeepMerge(key string, source interface{}) map[string]interface{} {
 		sep = "_"
 	}
 	switch v := source.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		/* We also need to get things like
 		 * "default_attributes:key" indexed. */
 		topLev := make([]string, len(v))
@@ -252,7 +252,7 @@ func DeepMerge(key string, source interface{}) map[string]interface{} {
 			merger[key] = topLev
 		}
 
-	case []interface{}:
+	case []any:
 		km := make([]string, 0, len(v))
 		mapMerge := make(map[string][]string)
 		for _, w := range v {
@@ -268,7 +268,7 @@ func DeepMerge(key string, source interface{}) map[string]interface{} {
 					mapMerge[nk] = mergeInterfaceMapChildren(mapMerge[nk], imv)
 				}
 			} else if vRef.Kind() == reflect.Slice {
-				for _, sv := range w.([]interface{}) {
+				for _, sv := range w.([]any) {
 					smMerge := DeepMerge("", sv)
 					// WARNING: This *may* be a little iffy
 					// still, there are some very weird
@@ -339,7 +339,7 @@ func getNKey(key string, subkey string, sep string) string {
 	return nkey
 }
 
-func mergeInterfaceMapChildren(strArr []string, val interface{}) []string {
+func mergeInterfaceMapChildren(strArr []string, val any) []string {
 	if reflect.ValueOf(val).Kind() == reflect.Slice {
 		strArr = append(strArr, val.([]string)...)
 	} else {
@@ -348,7 +348,7 @@ func mergeInterfaceMapChildren(strArr []string, val interface{}) []string {
 	return strArr
 }
 
-func stringify(source interface{}) string {
+func stringify(source any) string {
 	switch s := source.(type) {
 	case string:
 		return s

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 type testObj struct {
-	Name        string                 `json:"name"`
-	TestURLType string                 `json:"test_url_type"`
-	Normal      map[string]interface{} `json:"normal"`
-	RunList     []string               `json:"run_list"`
+	Name        string         `json:"name"`
+	TestURLType string         `json:"test_url_type"`
+	Normal      map[string]any `json:"normal"`
+	RunList     []string       `json:"run_list"`
 }
 
 func (to *testObj) GetName() string {
@@ -88,13 +88,13 @@ func TestGerror(t *testing.T) {
 
 func TestFlatten(t *testing.T) {
 	rl := []string{"recipe[foo]", "role[bar]"}
-	normmap := make(map[string]interface{})
+	normmap := make(map[string]any)
 	normmap["foo"] = "bar"
 	normmap["baz"] = "buz"
 	normmap["slice"] = []string{"fee", "fie", "fo"}
-	normmap["map"] = make(map[string]interface{})
-	normmap["map"].(map[string]interface{})["first"] = "mook"
-	normmap["map"].(map[string]interface{})["second"] = "nork"
+	normmap["map"] = make(map[string]any)
+	normmap["map"].(map[string]any)["first"] = "mook"
+	normmap["map"].(map[string]any)["second"] = "nork"
 	obj := &testObj{Name: "foo", TestURLType: "bar", RunList: rl, Normal: normmap}
 	flattened := FlattenObj(obj)
 	if _, ok := flattened["name"]; !ok {
@@ -130,13 +130,13 @@ func TestFlatten(t *testing.T) {
 
 func TestMapify(t *testing.T) {
 	rl := []string{"recipe[foo]", "role[bar]"}
-	normmap := make(map[string]interface{})
+	normmap := make(map[string]any)
 	normmap["foo"] = "bar"
 	normmap["baz"] = "buz"
 	normmap["slice"] = []string{"fee", "fie", "fo"}
-	normmap["map"] = make(map[string]interface{})
-	normmap["map"].(map[string]interface{})["first"] = "mook"
-	normmap["map"].(map[string]interface{})["second"] = "nork"
+	normmap["map"] = make(map[string]any)
+	normmap["map"].(map[string]any)["first"] = "mook"
+	normmap["map"].(map[string]any)["second"] = "nork"
 	obj := &testObj{Name: "foo", TestURLType: "bar", RunList: rl, Normal: normmap}
 	mapify := MapifyObject(obj)
 	if mapify["name"].(string) != obj.Name {
@@ -152,13 +152,13 @@ func TestMapify(t *testing.T) {
 
 func TestIndexify(t *testing.T) {
 	rl := []string{"recipe[foo]", "role[bar]"}
-	normmap := make(map[string]interface{})
+	normmap := make(map[string]any)
 	normmap["foo"] = "bar"
 	normmap["baz"] = "buz"
 	normmap["slice"] = []string{"fee", "fie", "fo"}
-	normmap["map"] = make(map[string]interface{})
-	normmap["map"].(map[string]interface{})["first"] = "mook"
-	normmap["map"].(map[string]interface{})["second"] = "nork"
+	normmap["map"] = make(map[string]any)
+	normmap["map"].(map[string]any)["first"] = "mook"
+	normmap["map"].(map[string]any)["second"] = "nork"
 	obj := &testObj{Name: "foo", TestURLType: "bar", RunList: rl, Normal: normmap}
 	flatten := FlattenObj(obj)
 	indexificate := Indexify(flatten)
@@ -217,7 +217,7 @@ func TestValidateAsVersion(t *testing.T) {
 	goodVersion2 := "1.0"
 	badVer1 := "1"
 	badVer2 := "foo"
-	var badVer3 interface{}
+	var badVer3 any
 	badVer3 = nil
 
 	if _, err := ValidateAsVersion(goodVersion); err != nil {

--- a/util/validations.go
+++ b/util/validations.go
@@ -49,7 +49,7 @@ func ValidateEnvName(name string) bool {
 	return !m
 }
 
-func ValidateAsString(str interface{}) (string, Gerror) {
+func ValidateAsString(str any) (string, Gerror) {
 	switch str := str.(type) {
 	case string:
 		return str, nil
@@ -62,7 +62,7 @@ func ValidateAsString(str interface{}) (string, Gerror) {
 	}
 }
 
-func ValidateAsBool(b interface{}) (bool, Gerror) {
+func ValidateAsBool(b any) (bool, Gerror) {
 	switch b := b.(type) {
 	case bool:
 		return b, nil
@@ -72,7 +72,7 @@ func ValidateAsBool(b interface{}) (bool, Gerror) {
 	}
 }
 
-func ValidateAsFieldString(str interface{}) (string, Gerror) {
+func ValidateAsFieldString(str any) (string, Gerror) {
 	switch str := str.(type) {
 	case string:
 		return str, nil
@@ -85,7 +85,7 @@ func ValidateAsFieldString(str interface{}) (string, Gerror) {
 	}
 }
 
-func ValidateAsVersion(ver interface{}) (string, Gerror) {
+func ValidateAsVersion(ver any) (string, Gerror) {
 	switch ver := ver.(type) {
 	case string:
 		validVer := regexp.MustCompile(`^(\d+)\.(\d+)(\.?)(\d+)?$`)
@@ -124,13 +124,13 @@ func ValidateAsVersion(ver interface{}) (string, Gerror) {
 	}
 }
 
-func ValidateAttributes(key string, attrs interface{}) (map[string]interface{}, Gerror) {
+func ValidateAttributes(key string, attrs any) (map[string]any, Gerror) {
 	switch attrs := attrs.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return attrs, nil
 	case nil:
 		/* Separate to do more validations above */
-		nilAttrs := make(map[string]interface{})
+		nilAttrs := make(map[string]any)
 		return nilAttrs, nil
 	default:
 		err := Errorf("Field '%s' is not a hash", key)
@@ -138,15 +138,15 @@ func ValidateAttributes(key string, attrs interface{}) (map[string]interface{}, 
 	}
 }
 
-func ValidateCookbookDivision(dname string, div interface{}) ([]map[string]interface{}, Gerror) {
+func ValidateCookbookDivision(dname string, div any) ([]map[string]any, Gerror) {
 	switch div := div.(type) {
-	case []interface{}:
-		var d []map[string]interface{}
+	case []any:
+		var d []map[string]any
 		err := Errorf("Invalid element in array value of '%s'.", dname)
 
 		for _, v := range div {
 			switch v := v.(type) {
-			case map[string]interface{}:
+			case map[string]any:
 				if len(v) < 4 {
 					return nil, err
 				}
@@ -227,9 +227,9 @@ func ValidateNumVersions(nr string) Gerror {
 	return nil
 }
 
-func ValidateCookbookMetadata(mdata interface{}) (map[string]interface{}, Gerror) {
+func ValidateCookbookMetadata(mdata any) (map[string]any, Gerror) {
 	switch mdata := mdata.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		if len(mdata) == 0 {
 			/* This error message would make more sense as
 			 * "Metadata empty" if the metadata is, you
@@ -293,7 +293,7 @@ func ValidateCookbookMetadata(mdata interface{}) (map[string]interface{}, Gerror
 		for _, v := range hashchk {
 			err := Errorf("Field 'metadata.%s' invalid", v)
 			switch hv := mdata[v].(type) {
-			case map[string]interface{}:
+			case map[string]any:
 				for _, j := range hv {
 					switch s := j.(type) {
 					case string:
@@ -303,7 +303,7 @@ func ValidateCookbookMetadata(mdata interface{}) (map[string]interface{}, Gerror
 								return nil, cerr
 							}
 						}
-					case map[string]interface{}:
+					case map[string]any:
 						if v != "groupings" {
 							err := Errorf("Invalid value '{[]}' for metadata.%s", v)
 							return nil, err
@@ -319,7 +319,7 @@ func ValidateCookbookMetadata(mdata interface{}) (map[string]interface{}, Gerror
 				}
 			case nil:
 				if v == "dependencies" {
-					mdata[v] = make(map[string]interface{})
+					mdata[v] = make(map[string]any)
 				}
 			default:
 				return nil, err
@@ -333,7 +333,7 @@ func ValidateCookbookMetadata(mdata interface{}) (map[string]interface{}, Gerror
 	}
 }
 
-func ValidateAsConstraint(t interface{}) (bool, Gerror) {
+func ValidateAsConstraint(t any) (bool, Gerror) {
 	err := Errorf("Invalid constraint")
 	switch t := t.(type) {
 	case string:
@@ -352,7 +352,7 @@ func ValidateAsConstraint(t interface{}) (bool, Gerror) {
 	}
 }
 
-func ValidateRunList(rl interface{}) ([]string, Gerror) {
+func ValidateRunList(rl any) ([]string, Gerror) {
 	switch rl := rl.(type) {
 	case []string:
 		for i, r := range rl {
@@ -461,7 +461,7 @@ func validateRecipeName(name string) bool {
 // CheckAdminPlusValidator checks that client/user json is not trying to set
 // admin and validator at the same time. This has to be checked separately to
 // make chef-pedent happy.
-func CheckAdminPlusValidator(jsonActor map[string]interface{}) Gerror {
+func CheckAdminPlusValidator(jsonActor map[string]any) Gerror {
 	var ab, vb bool
 	if adminVal, ok := jsonActor["admin"]; ok {
 		ab, _ = ValidateAsBool(adminVal)


### PR DESCRIPTION
## What

Applies the official [`golang.org/x/tools/gopls` modernize analyzer](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) across the codebase, scoped to the existing `go 1.21` floor. The `go` directive in `go.mod` is **intentionally unchanged**.

Changes (73 files, all non-vendor):

| Modernization | Count | Introduced in |
|---|---|---|
| `interface{}` → `any` | 453 | Go 1.18 |
| user-defined `min()` helper → built-in `min` | 1 + 3 call sites | Go 1.21 |
| manual loop → `slices.Contains` | 3 | Go 1.21 |
| manual loop → `slices.ContainsFunc` | 2 | Go 1.21 |

## What was deliberately left out

Modernizations that would require raising the `go` directive past 1.21 were **not** applied, to preserve build compatibility:

- `for i := 0; i < n; i++` → `for range n` (Go 1.22) — 25 sites
- `maps.Copy` — 9 sites
- `slices.Backward` (Go 1.23) — 2 sites

## Notes

- No behavioral changes — purely idiomatic cleanup.
- `go.mod`, `go.sum`, and `vendor/` are untouched.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all packages pass
- `gofmt -l` on changed files — clean