### PR TITLE
security: raise minimum TLS version to 1.2

### DIFF
--- a/goiardi.go
+++ b/goiardi.go
@@ -264,7 +264,7 @@ func main() {
 	var err error
 	srv := &http.Server{Addr: listenAddr, Handler: &interceptHandler{}}
 	if config.Config.UseSSL {
-		srv.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS10}
+		srv.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 		err = srv.ListenAndServeTLS(config.Config.SSLCert, config.Config.SSLKey)
 	} else {
 		err = srv.ListenAndServe()


### PR DESCRIPTION
## Issue

When `use-ssl` is enabled, the HTTPS server is configured with:

```go
srv.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS10}
```

`tls.VersionTLS10` permits **TLS 1.0 and 1.1**, both deprecated by [RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996) and subject to downgrade and cipher-weakness attacks (BEAST, etc.). A network MITM can negotiate a client down to TLS 1.0. All authenticated request bodies — and web-UI passwords posted to `/authenticate_user` — traverse this connection.

## Fix

Raise the minimum to `tls.VersionTLS12` (one line). TLS 1.2 is universally supported by current Chef clients; modern Go negotiates 1.3 when both sides support it.

## Verification

`go build ./...` and `go vet .` pass.