### PR TITLE
security: set HTTP server timeouts to mitigate slow-client DoS

### DIFF
--- a/goiardi.go
+++ b/goiardi.go
@@ -262,7 +262,19 @@ func main() {
 
 	listenAddr := config.ListenAddr()
 	var err error
-	srv := &http.Server{Addr: listenAddr, Handler: &interceptHandler{}}
+	srv := &http.Server{
+		Addr:    listenAddr,
+		Handler: &interceptHandler{},
+		// Bound how long a single connection may spend sending its
+		// request headers, and how long an idle keep-alive connection
+		// may linger, so that slow-sending clients (Slowloris) cannot
+		// tie up server goroutines indefinitely. Read/Write timeouts on
+		// the body are intentionally left unset to avoid interrupting
+		// large but legitimate cookbook uploads/downloads.
+		ReadHeaderTimeout: 60 * time.Second,
+		IdleTimeout:       180 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
 	if config.Config.UseSSL {
 		srv.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS10}
 		err = srv.ListenAndServeTLS(config.Config.SSLCert, config.Config.SSLKey)


### PR DESCRIPTION
## Issue

The `http.Server` is built with only `Addr` and `Handler`:

```go
srv := &http.Server{Addr: listenAddr, Handler: &interceptHandler{}}
```

No `ReadHeaderTimeout`, `IdleTimeout`, or `MaxHeaderBytes` is set. A client can open many connections and send request headers one byte at a time (a **Slowloris** attack), tying up one goroutine per connection indefinitely. There is no connection-count or rate limiting anywhere else. This is reachable **pre-authentication**, because request headers are read before `CheckHeader` runs in `ServeHTTP`.

## Fix

Set conservative limits:

- `ReadHeaderTimeout: 60s` — caps slow header sends (the Slowloris vector)
- `IdleTimeout: 180s` — reclaims idle keep-alive connections
- `MaxHeaderBytes: 1 MiB` — bounds header memory

`ReadTimeout`/`WriteTimeout` on the body are intentionally left unset so large but legitimate cookbook uploads/downloads are not interrupted.

## Verification

`go build ./...` and `go vet .` pass.