### PR TITLE
security: use constant-time comparison for password hash check

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -28,6 +28,7 @@ package user
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/gob"
 	"fmt"
@@ -563,7 +564,7 @@ func (u *User) CheckPasswd(password string) util.Gerror {
 		err := util.Errorf(perr.Error())
 		return err
 	}
-	if u.Passwd() != h {
+	if subtle.ConstantTimeCompare([]byte(u.Passwd()), []byte(h)) != 1 {
 		err := util.Errorf("password did not match")
 		return err
 	}


### PR DESCRIPTION
## Issue

`User.CheckPasswd` compares the stored password hash against the freshly computed hash with `!=`:

```go
if u.Passwd() != h {
    return util.Errorf("password did not match")
}
```

Go's string `!=` short-circuits on the first differing byte, so comparison time leaks how many leading bytes matched. The `/authenticate_user` endpoint is unauthenticated and accepts an attacker-controlled `name`/`password`, making this a timing oracle on the hash comparison — exactly the path where a constant-time comparison is expected.

## Fix

Compare with `crypto/subtle.ConstantTimeCompare`.

## Verification

`go build ./...`, `go vet ./user/`, and `go test ./user/` pass.