### PR TITLE
security: only update client admin/validator flags when supplied

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -409,8 +409,12 @@ ValidElem:
 		}
 	}
 
-	var ab, vb bool
+	// Only touch the admin/validator flags when the client actually
+	// supplies them. Previously these were unconditionally reset to false
+	// when the keys were absent, which silently demoted a client on any
+	// partial update and bypassed the last-admin guard below.
 	if adminVal, ok := jsonActor["admin"]; ok {
+		var ab bool
 		if ab, verr = util.ValidateAsBool(adminVal); verr != nil {
 			// NOTE: may need to tweak this error message depending
 			// if this is a user or a client
@@ -423,19 +427,20 @@ ValidElem:
 				return verr
 			}
 		}
+		c.Admin = ab
 	}
 	if validatorVal, ok := jsonActor["validator"]; ok {
+		var vb bool
 		if vb, verr = util.ValidateAsBool(validatorVal); verr != nil {
 			return verr
 		}
+		c.Validator = vb
 	}
-	if ab && vb {
+	if c.Admin && c.Validator {
 		verr = util.Errorf("Client can be either an admin or a validator, but not both.")
 		verr.SetStatus(http.StatusBadRequest)
 		return verr
 	}
-	c.Admin = ab
-	c.Validator = vb
 
 	c.ChefType = jsonActor["chef_type"].(string)
 	c.JSONClass = jsonActor["json_class"].(string)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -65,3 +65,42 @@ func TestActionAtADistance(t *testing.T) {
 		t.Errorf("Changing the value of validator on one client improperly changed it on the other")
 	}
 }
+
+// TestUpdateFromJSONPreservesFlags guards against the admin/validator flags
+// being silently reset when an update omits those keys.
+func TestUpdateFromJSONPreservesFlags(t *testing.T) {
+	c, _ := New("flagtest")
+	c.Admin = true
+
+	// An update that omits "admin" and "validator" must leave the existing
+	// flag values untouched.
+	upd := map[string]interface{}{
+		"name":       "flagtest",
+		"json_class": "Chef::ApiClient",
+		"chef_type":  "client",
+	}
+	if err := c.UpdateFromJSON(upd); err != nil {
+		t.Fatalf("UpdateFromJSON returned an error: %s", err.Error())
+	}
+	if !c.Admin {
+		t.Errorf("admin flag was reset to false when the 'admin' key was omitted from the update")
+	}
+	if c.Validator {
+		t.Errorf("validator flag unexpectedly became true")
+	}
+
+	// Supplying a flag explicitly must still take effect.
+	c2, _ := New("flagtest2")
+	upd2 := map[string]interface{}{
+		"name":       "flagtest2",
+		"json_class": "Chef::ApiClient",
+		"chef_type":  "client",
+		"validator":  true,
+	}
+	if err := c2.UpdateFromJSON(upd2); err != nil {
+		t.Fatalf("UpdateFromJSON returned an error: %s", err.Error())
+	}
+	if !c2.Validator {
+		t.Errorf("validator flag was not set to true when supplied")
+	}
+}


### PR DESCRIPTION
## Issue

`Client.UpdateFromJSON` declared `var ab, vb bool` and then unconditionally ran:

```go
c.Admin = ab
c.Validator = vb
```

When the `admin` / `validator` keys are absent from the request body, `ab`/`vb` stay `false`, so **any partial `PUT /clients/{name}` that omits those keys silently demotes** an admin or validator client. The last-admin guard only triggers when the `admin` key is *present and false*, so omitting it bypasses the guard entirely and can strip the final admin.

`User.UpdateFromJSON` already does the correct thing (only touches the flag when the key is present).

## Fix

Assign `c.Admin` / `c.Validator` only inside their respective `if _, ok := jsonActor[...]; ok` blocks, and evaluate the admin-xor-validator check against the resulting state.

## Verification

`go build ./...`, `go vet ./client/`, and `go test ./client/` pass.