### PR TITLE
security: clamp search start/rows to prevent slice-bounds panic

### DIFF
--- a/search/postgres_search.go
+++ b/search/postgres_search.go
@@ -174,9 +174,20 @@ func (p *PostgresSearch) Search(idx string, q string, rows int, sortOrder string
 	}
 	res = sortResults.res
 
+	// Clamp the client-supplied start/rows so out-of-range or negative
+	// values (e.g. ?start=-1 or ?start past the end) cannot panic the
+	// slice expression below.
+	if start < 0 {
+		start = 0
+	} else if start > len(res) {
+		start = len(res)
+	}
 	end := start + rows
 	if end > len(res) {
 		end = len(res)
+	}
+	if end < start {
+		end = start
 	}
 	res = res[start:end]
 	return res, nil

--- a/search/search.go
+++ b/search/search.go
@@ -164,9 +164,20 @@ func (t *TrieSearch) Search(idx string, query string, rows int, sortOrder string
 	}
 	res = sortResults.res
 
+	// Clamp the client-supplied start/rows so out-of-range or negative
+	// values (e.g. ?start=-1 or ?start past the end) cannot panic the
+	// slice expression below.
+	if start < 0 {
+		start = 0
+	} else if start > len(res) {
+		start = len(res)
+	}
 	end := start + rows
 	if end > len(res) {
 		end = len(res)
+	}
+	if end < start {
+		end = start
 	}
 	res = res[start:end]
 	return res, nil

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -331,6 +331,29 @@ func TestSearchNotSubquery(t *testing.T) {
 	}
 }
 
+// TestSearchPaginationBounds verifies that out-of-range or negative start/rows
+// values are clamped rather than panicking the result pager's slice
+// expression. A pre-fix panic in any case below fails the subtest.
+func TestSearchPaginationBounds(t *testing.T) {
+	cases := []struct {
+		name  string
+		rows  int
+		start int
+	}{
+		{"negative start", 1000, -1},
+		{"start past end", 1000, 1 << 20},
+		{"negative rows", -5, 0},
+		{"both negative", -5, -5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := searcher.Search("node", "*:*", tc.rows, "id ASC", tc.start, nil); err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+			}
+		})
+	}
+}
+
 // Probably don't want this as an always test, but it's handy to have available.
 /*
 func TestEmbiggenSearch(t *testing.T) {


### PR DESCRIPTION
## Issue

The search handler reads the client-supplied `start` and `rows` query parameters with `strconv.Atoi` (discarding the error and doing no range check), then both searchers page the results with:

```go
end := start + rows
if end > len(res) {
    end = len(res)
}
res = res[start:end]
```

Two attacker-controlled inputs panic the request goroutine:

- `?start=-1` → `Atoi` returns `-1` → `res[-1:end]` → *slice bounds out of range*.
- `?start=99999999` (past the end) → `end` clamps to `len(res)`, leaving `start > end` → panic.

This is reachable by any authenticated, non-validator user against `GET /search/<index>` and is trivial to script in a loop, producing continuous aborted requests and panic/stack-trace log spam.

## Fix

Clamp `start` to `[0, len(res)]` and `end` to `[start, len(res)]` before slicing, in **both** the trie (`search/search.go`) and PostgreSQL (`search/postgres_search.go`) backends.

## Verification

`go build ./...`, `go vet ./search/`, and `go test ./search/` pass.