### PR TITLE
security: bound request body size on bytes read, not Content-Length

### DIFF
--- a/goiardi.go
+++ b/goiardi.go
@@ -437,6 +437,16 @@ func (h *interceptHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body = reader
 	}
 
+	// Enforce the body size limit on the bytes actually read, not just the
+	// client-supplied Content-Length. A chunked request carries no
+	// Content-Length (so the check above is skipped entirely), and a
+	// gzipped body can inflate far beyond its compressed length; without
+	// this, either can be read unbounded into memory. The file_store
+	// handler wraps its own (larger) MaxBytesReader, so it is excluded.
+	if !strings.HasPrefix(r.URL.Path, "/file_store") {
+		r.Body = http.MaxBytesReader(w, r.Body, config.Config.JSONReqMaxSize)
+	}
+
 	// Set up the context for the request. At this time, this means setting
 	// the opUser for this request for most (but not all) types of requests.
 	// At this time the exceptions are "/file_store", "/universe", and


### PR DESCRIPTION
## Issue

The request-size guard in `ServeHTTP` only checks the client-supplied `Content-Length`:

```go
if !strings.HasPrefix(r.URL.Path, "/file_store") && r.ContentLength > config.Config.JSONReqMaxSize {
    ...reject...
}
```

The body is then passed to `json.NewDecoder` (and, for gzip requests, `gzip.NewReader`) with no limit on the bytes actually read. Two ways around it:

1. **Chunked transfer** — a request with `Transfer-Encoding: chunked` has `r.ContentLength == -1`, so the check is skipped and the body is read unbounded into memory.
2. **Decompression bomb** — a small gzipped body (well under the limit) can inflate to many GB; the size was checked on the *compressed* length only.

Either lets an authenticated client OOM the server.

## Fix

After the existing checks and the gzip-decompression step, wrap the body in `http.MaxBytesReader(w, r.Body, JSONReqMaxSize)` for all non-`/file_store` paths. Because it wraps the (already decompressed) reader, it bounds the real bytes read regardless of `Content-Length` or `Content-Encoding`. `/file_store` is excluded — its handler already applies its own larger `MaxBytesReader`.

## Verification

`go build ./...` and `go vet .` pass.