### PR TITLE
security: create log file with 0640 instead of world-writable 0666

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -448,7 +448,7 @@ func ParseConfigOptions() error {
 		Config.SysLog = opts.SysLog
 	}
 	if Config.LogFile != "" {
-		lfp, lerr := os.OpenFile(Config.LogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, os.ModeAppend|0666)
+		lfp, lerr := os.OpenFile(Config.LogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, os.ModeAppend|0640)
 		if lerr != nil {
 			log.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
## Issue

The log file is created world-writable:

```go
lfp, lerr := os.OpenFile(Config.LogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, os.ModeAppend|0666)
```

Mode `0666` (subject to umask) makes the file world-readable and world-writable. Any local user can then read operational log detail or tamper with / truncate the audit trail.

## Fix

Create the file with `0640` (owner read/write, group read, no world access).

## Verification

`go build ./...` and `go vet ./config/` pass.

## Note

This is a local-permissions hardening fix (`LogFile` is operator-supplied, not remote input), included as part of a small security pass.