### PR TITLE
security: don't trust X-Forwarded-For when gating /debug/pprof

### DIFF
--- a/goiardi.go
+++ b/goiardi.go
@@ -311,6 +311,32 @@ func apiTimerMaster(apiChan chan *apiTimerInfo, metricsBackend met.Backend) {
 	}
 }
 
+// pprofAllowed reports whether a request to /debug/* may proceed. Access is
+// restricted to loopback and operator-whitelisted addresses. The
+// X-Forwarded-For header is attacker-controlled, so it is only consulted when
+// the direct peer (remoteAddr) is itself trusted — i.e. a local reverse proxy.
+// Otherwise a remote client could spoof a loopback value to bypass the gate.
+func pprofAllowed(remoteAddr, xForwardedFor string) bool {
+	remoteIP, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+	rIP := net.ParseIP(remoteIP)
+	if !rIP.IsLoopback() && !config.PprofWhitelisted(rIP) {
+		return false
+	}
+	// The direct peer is trusted; if it forwarded a client address, that
+	// client must also be loopback or whitelisted.
+	if xForwardedFor != "" {
+		fwded := strings.Split(xForwardedFor, ", ")
+		xFIP := net.ParseIP(fwded[len(fwded)-1])
+		if !xFIP.IsLoopback() && !config.PprofWhitelisted(xFIP) {
+			return false
+		}
+	}
+	return true
+}
+
 func (h *interceptHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	/* knife sometimes sends URL paths that start with //. Redirecting
 	 * worked for GETs, but since it was breaking POSTs and screwing with
@@ -323,27 +349,10 @@ func (h *interceptHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO: set this to verbosity level 4 or so
 	logger.Debugf("Serving %s -- %s", r.URL.Path, r.Method)
 
-	// block /debug/pprof if not localhost
+	// block /debug/pprof unless the request comes from a trusted source
 	if strings.HasPrefix(r.URL.Path, "/debug") {
-		fwded := strings.Split(r.Header.Get("X-Forwarded-For"), ", ")
-		remoteIP, _, rerr := net.SplitHostPort(r.RemoteAddr)
-		var block bool
-		if rerr == nil {
-			var xForwarded string
-			if len(fwded) != 0 {
-				xForwarded = fwded[len(fwded)-1]
-			}
-			rIP := net.ParseIP(remoteIP)
-			xFIP := net.ParseIP(xForwarded)
-			if !rIP.IsLoopback() && !xFIP.IsLoopback() && !config.PprofWhitelisted(rIP) && !config.PprofWhitelisted(xFIP) {
-				logger.Debugf("blocked %s (x-forwarded-for: %s) from accessing /debug/pprof!", rIP.String(), xFIP.String())
-				block = true
-			}
-		} else {
-			logger.Debugf("remote ip %q is bad, not IP:port (blocking from /debug/pprof)", r.RemoteAddr)
-			block = true
-		}
-		if block {
+		if !pprofAllowed(r.RemoteAddr, r.Header.Get("X-Forwarded-For")) {
+			logger.Debugf("blocked %s (x-forwarded-for: %q) from accessing /debug/pprof!", r.RemoteAddr, r.Header.Get("X-Forwarded-For"))
 			http.Error(w, "Forbidden!", http.StatusForbidden)
 			return
 		}

--- a/pprof_test.go
+++ b/pprof_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2013-2017, Jeremy Bingham (<jeremy@goiardi.gl>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "testing"
+
+func TestPprofAllowed(t *testing.T) {
+	// The whitelist is empty in this test, so only loopback peers are
+	// trusted. These cases verify that an attacker-supplied X-Forwarded-For
+	// header cannot bypass the loopback gate.
+	cases := []struct {
+		name          string
+		remoteAddr    string
+		xForwardedFor string
+		want          bool
+	}{
+		{"loopback peer, no XFF", "127.0.0.1:5000", "", true},
+		{"ipv6 loopback peer, no XFF", "[::1]:5000", "", true},
+		{"remote peer, no XFF", "203.0.113.7:5000", "", false},
+		// The core vulnerability: a remote peer spoofs a loopback
+		// X-Forwarded-For value. It must still be blocked.
+		{"remote peer spoofs loopback XFF", "203.0.113.7:5000", "127.0.0.1", false},
+		{"remote peer spoofs loopback XFF in chain", "203.0.113.7:5000", "10.0.0.1, 127.0.0.1", false},
+		// A trusted (loopback) reverse proxy forwarding a real client:
+		// the forwarded client address governs the decision.
+		{"loopback proxy, remote client", "127.0.0.1:5000", "203.0.113.7", false},
+		{"loopback proxy, loopback client", "127.0.0.1:5000", "127.0.0.1", true},
+		// Malformed input must fail closed.
+		{"bad remote addr", "not-an-address", "", false},
+		{"loopback proxy, garbage XFF", "127.0.0.1:5000", "garbage", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pprofAllowed(tc.remoteAddr, tc.xForwardedFor); got != tc.want {
+				t.Errorf("pprofAllowed(%q, %q) = %v, want %v", tc.remoteAddr, tc.xForwardedFor, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue

`/debug/*` is excluded from the authentication check in `ServeHTTP`, and `net/http/pprof` is registered on the default mux. The only thing protecting the profiling endpoints (heap/goroutine/CPU profiles, `/debug/pprof/cmdline`) is an IP allow-list, which blocked a request only when **both** the socket peer and the last `X-Forwarded-For` entry were non-loopback and non-whitelisted:

```go
if !rIP.IsLoopback() && !xFIP.IsLoopback() && !config.PprofWhitelisted(rIP) && !config.PprofWhitelisted(xFIP) {
    block = true
}
```

`X-Forwarded-For` is fully attacker-controlled when goiardi is exposed directly (no fronting proxy). A remote client simply sends:

```
curl -H 'X-Forwarded-For: 127.0.0.1' http://target:4545/debug/pprof/heap
```

`xFIP.IsLoopback()` is then true, the `&&` chain is false, `block` stays false, and the unauthenticated profile dump (which can leak secrets/keys/request data from memory, and can be abused for CPU-exhaustion DoS) is served.

## Fix

Extract the gate into a pure `pprofAllowed(remoteAddr, xForwardedFor)` function and invert the trust model: the **direct peer** (`r.RemoteAddr`) must be loopback or whitelisted. `X-Forwarded-For` is only consulted when the peer is itself trusted (a local reverse proxy), in which case the forwarded client address must also be allowed. Malformed addresses fail closed.

This preserves the legitimate reverse-proxy deployment (proxy on loopback forwarding a whitelisted client) while closing the spoof.

## Tests

Adds `TestPprofAllowed` (new `pprof_test.go`), a table-driven test covering: loopback peer, remote peer, **remote peer spoofing a loopback `X-Forwarded-For`** (the vulnerability), a trusted proxy forwarding allowed/disallowed clients, and malformed input.

## Verification

`go build ./...`, `go vet .`, and `go test -run TestPprofAllowed .` pass.